### PR TITLE
fix maskbrush stationary cursor wheel rendering

### DIFF
--- a/js/ui/tool/maskbrush.js
+++ b/js/ui/tool/maskbrush.js
@@ -155,12 +155,23 @@ const maskBrushTool = () =>
 					uiCtx.fill();
 				};
 
+				state.redraw = () => {
+					state.movecb({
+						...mouse.coords.world.pos,
+						evn: {
+							clientX: mouse.coords.window.pos.x,
+							clientY: mouse.coords.window.pos.y,
+						},
+					});
+				};
+
 				state.wheelcb = (evn) => {
 					if (!evn.evn.ctrlKey) {
 						state.brushSize = state.setBrushSize(
 							state.brushSize -
 								Math.floor(state.config.brushScrollSpeed * evn.delta)
 						);
+						state.redraw();
 					}
 				};
 


### PR DESCRIPTION
Brush did not redraw when changing brush size. now it does.

Some tiny fixes after a big merge as always. Will be updating as I find them while using the tool.

Signed-off-by: Victor Seiji Hariki <victorseijih@gmail.com>