### PR TITLE
dynamic canvas scaling?

### DIFF
--- a/css/ui/layers.css
+++ b/css/ui/layers.css
@@ -132,3 +132,72 @@
 	flex: 1;
 	height: 25px;
 }
+
+/* Resizing buttons */
+.expand-button {
+	display: flex;
+
+	align-items: center;
+	justify-content: center;
+
+	margin: 0;
+	padding: 0;
+	border: 0;
+
+	background-color: transparent;
+
+	cursor: pointer;
+
+	transition-duration: 300ms;
+
+	border: 2px solid #293d3d30;
+}
+
+.expand-button::after {
+	content: "";
+
+	background-color: #293d3d77;
+
+	mask-image: url("/res/icons/chevron-up.svg");
+	mask-size: contain;
+
+	width: 60px;
+	height: 60px;
+}
+
+.expand-button:hover::after {
+	background-color: #466;
+}
+
+.expand-button.right::after {
+	transform: rotate(90deg);
+}
+
+.expand-button.bottom::after {
+	transform: rotate(180deg);
+}
+
+.expand-button.left::after {
+	transform: rotate(270deg);
+}
+
+.expand-button.left {
+	border-top-left-radius: 10px;
+	border-bottom-left-radius: 10px;
+}
+.expand-button.top {
+	border-top-left-radius: 10px;
+	border-top-right-radius: 10px;
+}
+.expand-button.right {
+	border-top-right-radius: 10px;
+	border-bottom-right-radius: 10px;
+}
+.expand-button.bottom {
+	border-bottom-right-radius: 10px;
+	border-bottom-left-radius: 10px;
+}
+
+.expand-button:hover {
+	backdrop-filter: brightness(60%);
+}

--- a/css/ui/layers.css
+++ b/css/ui/layers.css
@@ -199,5 +199,5 @@
 }
 
 .expand-button:hover {
-	backdrop-filter: brightness(60%);
+	background-color: #293d3d77;
 }

--- a/js/index.js
+++ b/js/index.js
@@ -343,10 +343,7 @@ function newImage(evt) {
 	clearPaintedMask();
 	uil.layers.forEach(({layer}) => {
 		commands.runCommand("eraseImage", "Clear Canvas", {
-			x: -layer.origin.x,
-			y: -layer.origin.y,
-			w: layer.canvas.width,
-			h: layer.canvas.height,
+			...layer.bb,
 			ctx: layer.ctx,
 		});
 	});

--- a/js/index.js
+++ b/js/index.js
@@ -343,8 +343,8 @@ function newImage(evt) {
 	clearPaintedMask();
 	uil.layers.forEach(({layer}) => {
 		commands.runCommand("eraseImage", "Clear Canvas", {
-			x: 0,
-			y: 0,
+			x: -layer.origin.x,
+			y: -layer.origin.y,
 			w: layer.canvas.width,
 			h: layer.canvas.height,
 			ctx: layer.ctx,
@@ -353,7 +353,7 @@ function newImage(evt) {
 }
 
 function clearPaintedMask() {
-	maskPaintCtx.clearRect(0, 0, maskPaintCanvas.width, maskPaintCanvas.height);
+	maskPaintLayer.clear();
 }
 
 function march(bb, options = {}) {
@@ -558,8 +558,16 @@ function drawBackground() {
 	// Checkerboard
 	let darkTileColor = "#333";
 	let lightTileColor = "#555";
-	for (var x = 0; x < bgLayer.canvas.width; x += 64) {
-		for (var y = 0; y < bgLayer.canvas.height; y += 64) {
+	for (
+		var x = -bgLayer.origin.x - 64;
+		x < bgLayer.canvas.width - bgLayer.origin.x;
+		x += 64
+	) {
+		for (
+			var y = -bgLayer.origin.y - 64;
+			y < bgLayer.canvas.height - bgLayer.origin.y;
+			y += 64
+		) {
 			bgLayer.ctx.fillStyle =
 				(x + y) % 128 === 0 ? lightTileColor : darkTileColor;
 			bgLayer.ctx.fillRect(x, y, 64, 64);

--- a/js/initalize/debug.populate.js
+++ b/js/initalize/debug.populate.js
@@ -17,6 +17,19 @@ mouse.listen.world.onmousemove.on((evn) => {
 	canvasYInfo.textContent = evn.y;
 	snapXInfo.textContent = evn.x + snap(evn.x);
 	snapYInfo.textContent = evn.y + snap(evn.y);
+
+	if (debug) {
+		debugLayer.clear();
+		debugCtx.fillStyle = "#F0F";
+		debugCtx.beginPath();
+		debugCtx.arc(viewport.cx, viewport.cy, 5, 0, Math.PI * 2);
+		debugCtx.fill();
+
+		debugCtx.fillStyle = "#0FF";
+		debugCtx.beginPath();
+		debugCtx.arc(evn.x, evn.y, 5, 0, Math.PI * 2);
+		debugCtx.fill();
+	}
 });
 
 /**

--- a/js/initalize/layers.populate.js
+++ b/js/initalize/layers.populate.js
@@ -269,8 +269,14 @@ mouse.listen.window.btn.middle.onpaint.on((evn) => {
 		viewport.cy = worldInit.y + (evn.iy - evn.y) / viewport.zoom;
 
 		// Limits
-		viewport.cx = Math.max(Math.min(viewport.cx, imageCollection.size.w), 0);
-		viewport.cy = Math.max(Math.min(viewport.cy, imageCollection.size.h), 0);
+		viewport.cx = Math.max(
+			Math.min(viewport.cx, imageCollection.size.w - imageCollection.origin.x),
+			-imageCollection.origin.x
+		);
+		viewport.cy = Math.max(
+			Math.min(viewport.cy, imageCollection.size.h - imageCollection.origin.y),
+			-imageCollection.origin.y
+		);
 
 		// Draw Viewport location
 	}

--- a/js/initalize/layers.populate.js
+++ b/js/initalize/layers.populate.js
@@ -143,8 +143,6 @@ const uiCtx = uiCanvas.getContext("2d", {desynchronized: true});
 
 debugLayer.hide(); // Hidden by default
 
-layers.registerCollection("mask", {name: "Mask Layers", requiresActive: true});
-
 // Where CSS and javascript magic happens to make the canvas viewport work
 /**
  * The global viewport object (may be modularized in the future). All

--- a/js/lib/layers.d.js
+++ b/js/lib/layers.d.js
@@ -1,0 +1,47 @@
+/**
+ * A layer
+ *
+ * @typedef {object} Layer
+ * @property {string} id The id of the layer
+ * @property {string} key A identifier for the layer
+ * @property {string} name The display name of the layer
+ * @property {BoundingBox} bb The current bounding box of the layer, in layer coordinates
+ * @property {Size} resolution The resolution of the layer (canvas)
+ * @property {boolean} full If the layer is a full layer (occupies the full collection)
+ * @property {number} x The x coordinate of the layer
+ * @property {number} y The y coordinate of the layer
+ * @property {number} width The width of the layer
+ * @property {number} w The width of the layer
+ * @property {number} height The height of the layer
+ * @property {number} h The height of the layer
+ * @property {Point} origin The location of the origin ((0, 0) point) of the layer (If canvas goes from -64, -32 to 128, 512, it's (64, 32))
+ * @property {HTMLCanvasElement} canvas The canvas element of the layers
+ * @property {CanvasRenderingContext2D} ctx The context of the canvas of the layer
+ * @property {function} clear Clears the layer contents
+ * @property {function} moveAfter Moves this layer to another level (after given layer)
+ * @property {function} moveBefore Moves this layer to another level (before given layer)
+ * @property {function} moveTo Moves this layer to another location
+ * @property {function} resize Resizes the layer in place
+ * @property {function} hide Hides the layer
+ * @property {function} unhide Unhides the layer
+ */
+
+/**
+ * A layer collection
+ *
+ * @typedef {object} LayerCollection
+ * @property {string} id The id of the collection
+ * @property {string} key A identifier for the collection
+ * @property {string} name The display name of the collection
+ * @property {HTMLDivElement} element The base element of the collection
+ * @property {HTMLDivElement} inputElement The element used for input handling for the collection
+ * @property {Point} inputOffset The offset for calculating layer coordinates from input element input information
+ * @property {Point} origin The location of the origin ((0, 0) point) of the collection (If canvas goes from -64, -32 to 128, 512, it's (64, 32))
+ * @property {BoundingBox} bb The current bounding box of the collection, in layer coordinates
+ * @property {{[key: string]: Layer}} layers An object for quick access to named layers of the collection
+ * @property {Size} size The size of the collection (CSS)
+ * @property {Size} resolution The resolution of the collection (canvas)
+ * @property {function} expand Expands the collection and its full layers by the specified amounts
+ * @property {function} registerLayer Registers a new layer
+ * @property {function} deleteLayer Deletes a layer from the collection
+ */

--- a/js/lib/util.js
+++ b/js/lib/util.js
@@ -306,7 +306,7 @@ function cropCanvas(sourceCanvas, options = {}) {
 		x: (srcCtx.origin && -srcCtx.origin.x) || 0,
 		y: (srcCtx.origin && -srcCtx.origin.y) || 0,
 	};
-	var imageData = srcCtx.getImageData(offset.x, offset.y, w, h);
+	var imageData = srcCtx.getImageDataRoot(0, 0, w, h);
 	/** @type {BoundingBox} */
 	const bb = new BoundingBox();
 
@@ -334,7 +334,8 @@ function cropCanvas(sourceCanvas, options = {}) {
 	bb.w = maxx - minx + 1 + 2 * options.border;
 	bb.h = maxy - miny + 1 + 2 * options.border;
 
-	if (maxx < 0) throw new NoContentError("Canvas has no content to crop");
+	if (!Number.isFinite(maxx))
+		throw new NoContentError("Canvas has no content to crop");
 
 	var cutCanvas = document.createElement("canvas");
 	cutCanvas.width = bb.w;

--- a/js/lib/util.js
+++ b/js/lib/util.js
@@ -11,6 +11,19 @@
  */
 
 /**
+ * Represents a size
+ */
+class Size {
+	w = 0;
+	h = 0;
+
+	constructor({w, h} = {w: 0, h: 0}) {
+		this.w = w;
+		this.h = h;
+	}
+}
+
+/**
  * Represents a simple bouding box
  */
 class BoundingBox {
@@ -288,14 +301,19 @@ function cropCanvas(sourceCanvas, options = {}) {
 
 	const w = sourceCanvas.width;
 	const h = sourceCanvas.height;
-	var imageData = sourceCanvas.getContext("2d").getImageData(0, 0, w, h);
+	const srcCtx = sourceCanvas.getContext("2d");
+	const offset = {
+		x: (srcCtx.origin && -srcCtx.origin.x) || 0,
+		y: (srcCtx.origin && -srcCtx.origin.y) || 0,
+	};
+	var imageData = srcCtx.getImageData(offset.x, offset.y, w, h);
 	/** @type {BoundingBox} */
 	const bb = new BoundingBox();
 
-	let minx = w;
-	let maxx = -1;
-	let miny = h;
-	let maxy = -1;
+	let minx = Infinity;
+	let maxx = -Infinity;
+	let miny = Infinity;
+	let maxy = -Infinity;
 
 	for (let y = 0; y < h; y++) {
 		for (let x = 0; x < w; x++) {
@@ -303,10 +321,10 @@ function cropCanvas(sourceCanvas, options = {}) {
 			const index = (y * w + x) * 4; // OHHH OK this is setting the imagedata.data uint8clampeddataarray index for the specified x/y coords
 			//this part i get, this is checking that 4th RGBA byte for opacity
 			if (imageData.data[index + 3] > 0) {
-				minx = Math.min(minx, x);
-				maxx = Math.max(maxx, x);
-				miny = Math.min(miny, y);
-				maxy = Math.max(maxy, y);
+				minx = Math.min(minx, x + offset.x);
+				maxx = Math.max(maxx, x + offset.x);
+				miny = Math.min(miny, y + offset.y);
+				maxy = Math.max(maxy, y + offset.y);
 			}
 		}
 	}

--- a/js/lib/util.js
+++ b/js/lib/util.js
@@ -244,7 +244,12 @@ function makeWriteOnce(obj, name = "write-once object", exceptions = []) {
  * @returns	an offset, in which [i + offset = (a location snapped to the grid)]
  */
 function snap(i, offset = 0, gridSize = 64) {
-	const modulus = (i - offset) % gridSize;
+	let diff = i - offset;
+	if (diff < 0) {
+		diff += gridSize * Math.ceil(Math.abs(diff / gridSize));
+	}
+
+	const modulus = diff % gridSize;
 	var snapOffset = modulus;
 
 	if (modulus > gridSize / 2) snapOffset = modulus - gridSize;

--- a/js/lib/util.js
+++ b/js/lib/util.js
@@ -364,8 +364,8 @@ function downloadCanvas(options = {}) {
 	defaultOpt(options, {
 		cropToContent: true,
 		canvas: uil.getVisible({
-			x: 0,
-			y: 0,
+			x: -imageCollection.origin.x,
+			y: -imageCollection.origin.y,
 			w: imageCollection.size.w,
 			h: imageCollection.size.h,
 		}),
@@ -384,6 +384,7 @@ function downloadCanvas(options = {}) {
 	var croppedCanvas = options.cropToContent
 		? cropCanvas(options.canvas).canvas
 		: options.canvas;
+
 	if (croppedCanvas != null) {
 		croppedCanvas.toBlob((blob) => {
 			link.href = URL.createObjectURL(blob);

--- a/js/lib/util.js
+++ b/js/lib/util.js
@@ -363,12 +363,7 @@ function cropCanvas(sourceCanvas, options = {}) {
 function downloadCanvas(options = {}) {
 	defaultOpt(options, {
 		cropToContent: true,
-		canvas: uil.getVisible({
-			x: -imageCollection.origin.x,
-			y: -imageCollection.origin.y,
-			w: imageCollection.size.w,
-			h: imageCollection.size.h,
-		}),
+		canvas: uil.getVisible(imageCollection.bb),
 		filename:
 			new Date()
 				.toISOString()

--- a/js/ui/floating/layers.js
+++ b/js/ui/floating/layers.js
@@ -298,23 +298,13 @@ const uil = {
 		canvas.width = bb.w;
 		canvas.height = bb.h;
 		if (options.includeBg)
-			ctx.drawImage(
-				bgLayer.canvas,
-				bb.x + bgLayer.origin.x,
-				bb.y + bgLayer.origin.y,
-				bb.w,
-				bb.h,
-				0,
-				0,
-				bb.w,
-				bb.h
-			);
+			ctx.drawImage(bgLayer.canvas, bb.x, bb.y, bb.w, bb.h, 0, 0, bb.w, bb.h);
 		this.layers.forEach((layer) => {
 			if (!layer.hidden)
 				ctx.drawImage(
 					layer.layer.canvas,
-					bb.x + layer.layer.origin.x,
-					bb.y + layer.layer.origin.y,
+					bb.x,
+					bb.y,
 					bb.w,
 					bb.h,
 					0,

--- a/js/ui/floating/layers.js
+++ b/js/ui/floating/layers.js
@@ -298,13 +298,23 @@ const uil = {
 		canvas.width = bb.w;
 		canvas.height = bb.h;
 		if (options.includeBg)
-			ctx.drawImage(bgLayer.canvas, bb.x, bb.y, bb.w, bb.h, 0, 0, bb.w, bb.h);
+			ctx.drawImage(
+				bgLayer.canvas,
+				bb.x + bgLayer.origin.x,
+				bb.y + bgLayer.origin.y,
+				bb.w,
+				bb.h,
+				0,
+				0,
+				bb.w,
+				bb.h
+			);
 		this.layers.forEach((layer) => {
 			if (!layer.hidden)
 				ctx.drawImage(
 					layer.layer.canvas,
-					bb.x,
-					bb.y,
+					bb.x + layer.layer.origin.x,
+					bb.y + layer.layer.origin.y,
 					bb.w,
 					bb.h,
 					0,

--- a/js/ui/tool/colorbrush.js
+++ b/js/ui/tool/colorbrush.js
@@ -282,7 +282,7 @@ const colorBrushTool = () =>
 					const canvas = state.drawLayer.canvas;
 					const ctx = state.drawLayer.ctx;
 
-					const cropped = cropCanvas(canvas, {border: 10, origin: uil.origin});
+					const cropped = cropCanvas(canvas, {border: 10});
 					const bb = cropped.bb;
 
 					commands.runCommand("drawImage", "Color Brush Draw", {

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -44,7 +44,7 @@ const _monitorProgress = (bb, oncheck = null) => {
 			layer.ctx.fillRect(1, 1, bb.w * data.progress, 10);
 
 			// Draw Progress Text
-			layer.ctx.clearRect(0, 11, expanded.w, 40);
+			layer.clear();
 			layer.ctx.fillStyle = "#FFF";
 
 			layer.ctx.fillRect(0, 15, 60, 25);
@@ -295,8 +295,7 @@ const _generate = async (endpoint, request, bb, options = {}) => {
 	});
 
 	const redraw = (url = images[at]) => {
-		if (url === null)
-			layer.ctx.clearRect(0, 0, layer.canvas.width, layer.canvas.height);
+		if (url === null) layer.clear();
 		if (!url) return;
 
 		const img = new Image();

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -318,7 +318,7 @@ const _generate = async (endpoint, request, bb, options = {}) => {
 				ctx.drawImage(keepUnmaskCanvas, 0, 0);
 			}
 
-			layer.ctx.clearRect(0, 0, layer.canvas.width, layer.canvas.height);
+			layer.clear();
 			layer.ctx.drawImage(
 				canvas,
 				0,
@@ -765,8 +765,8 @@ const dream_generate_callback = async (bb, resolution, state) => {
 			bbCtx.globalCompositeOperation = "destination-in";
 			bbCtx.drawImage(
 				maskPaintCanvas,
-				bb.x,
-				bb.y,
+				bb.x + maskPaintLayer.origin.x,
+				bb.y + maskPaintLayer.origin.y,
 				bb.w,
 				bb.h,
 				0,
@@ -793,8 +793,8 @@ const dream_generate_callback = async (bb, resolution, state) => {
 			bbCtx.globalCompositeOperation = "destination-out"; // ???
 			bbCtx.drawImage(
 				maskPaintCanvas,
-				bb.x,
-				bb.y,
+				bb.x + maskPaintLayer.origin.x,
+				bb.y + maskPaintLayer.origin.y,
 				bb.w,
 				bb.h,
 				0,
@@ -915,7 +915,17 @@ const dream_img2img_callback = (bb, resolution, state) => {
 	bbCtx.fillStyle = state.invertMask ? "#FFFF" : "#000F";
 	bbCtx.fillRect(0, 0, bb.w, bb.h);
 	bbCtx.globalCompositeOperation = "destination-out";
-	bbCtx.drawImage(maskPaintCanvas, bb.x, bb.y, bb.w, bb.h, 0, 0, bb.w, bb.h);
+	bbCtx.drawImage(
+		maskPaintCanvas,
+		bb.x + maskPaintLayer.origin.x,
+		bb.y + maskPaintLayer.origin.y,
+		bb.w,
+		bb.h,
+		0,
+		0,
+		bb.w,
+		bb.h
+	);
 
 	bbCtx.globalCompositeOperation = "destination-atop";
 	bbCtx.fillStyle = state.invertMask ? "#000F" : "#FFFF";

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -39,12 +39,13 @@ const _monitorProgress = (bb, oncheck = null) => {
 
 			oncheck && oncheck(data);
 
+			layer.clear();
+
 			// Draw Progress Bar
 			layer.ctx.fillStyle = "#5F5";
 			layer.ctx.fillRect(1, 1, bb.w * data.progress, 10);
 
 			// Draw Progress Text
-			layer.clear();
 			layer.ctx.fillStyle = "#FFF";
 
 			layer.ctx.fillRect(0, 15, 60, 25);

--- a/js/ui/tool/interrogate.js
+++ b/js/ui/tool/interrogate.js
@@ -4,10 +4,8 @@ const interrogateTool = () =>
 		"Interrogate",
 		(state, opt) => {
 			// Draw new cursor immediately
-			ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
-			state.mousemovecb({
-				...mouse.coords.world.pos,
-			});
+			ovLayer.clear();
+			state.redraw();
 
 			// Start Listeners
 			mouse.listen.world.onmousemove.on(state.mousemovecb);
@@ -37,8 +35,7 @@ const interrogateTool = () =>
 				state.invertMask = false;
 				state.overMaskPx = 0;
 
-				state.erasePrevReticle = () =>
-					ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+				state.erasePrevReticle = () => ovLayer.clear();
 
 				state.mousemovecb = (evn) => {
 					state.erasePrevReticle();

--- a/js/ui/tool/maskbrush.js
+++ b/js/ui/tool/maskbrush.js
@@ -240,12 +240,7 @@ const maskBrushTool = () =>
 					clearMaskButton.textContent = "Clear";
 					clearMaskButton.title = "Clears Painted Mask";
 					clearMaskButton.onclick = () => {
-						maskPaintCtx.clearRect(
-							0,
-							0,
-							maskPaintCanvas.width,
-							maskPaintCanvas.height
-						);
+						maskPaintLayer.clear();
 					};
 
 					const previewMaskButton = document.createElement("button");

--- a/js/ui/tool/select.js
+++ b/js/ui/tool/select.js
@@ -4,7 +4,7 @@ const selectTransformTool = () =>
 		"Select Image",
 		(state, opt) => {
 			// Draw new cursor immediately
-			ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+			ovLayer.clear();
 			state.movecb(mouse.coords.world.pos);
 
 			// Canvas left mouse handlers
@@ -46,7 +46,7 @@ const selectTransformTool = () =>
 			state.reset();
 
 			// Resets cursor
-			ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+			ovLayer.clear();
 
 			// Clears overlay
 			imageCollection.inputElement.style.cursor = "auto";
@@ -80,7 +80,7 @@ const selectTransformTool = () =>
 				state.lastMouseMove = null;
 
 				state.redraw = () => {
-					ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+					ovLayer.clear();
 					state.movecb(state.lastMouseMove);
 				};
 
@@ -186,7 +186,7 @@ const selectTransformTool = () =>
 
 				// Mouse move handler. As always, also renders cursor
 				state.movecb = (evn) => {
-					ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+					ovLayer.clear();
 					uiCtx.clearRect(0, 0, uiCanvas.width, uiCanvas.height);
 					imageCollection.inputElement.style.cursor = "auto";
 					state.lastMouseTarget = evn.target;

--- a/js/ui/tool/stamp.js
+++ b/js/ui/tool/stamp.js
@@ -6,7 +6,7 @@ const stampTool = () =>
 			state.loaded = true;
 
 			// Draw new cursor immediately
-			ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+			ovLayer.clear();
 			state.movecb({...mouse.coords.world.pos});
 
 			// Start Listeners
@@ -47,7 +47,7 @@ const stampTool = () =>
 				child.classList.remove("active");
 			});
 
-			ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+			ovLayer.clear();
 		},
 		{
 			init: (state) => {
@@ -88,7 +88,7 @@ const stampTool = () =>
 						state.selected = null;
 					}
 
-					ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+					ovLayer.clear();
 					if (state.loaded) state.movecb(state.lastMouseMove);
 				};
 
@@ -300,7 +300,7 @@ const stampTool = () =>
 
 					state.lastMouseMove = evn;
 
-					ovCtx.clearRect(0, 0, ovCanvas.width, ovCanvas.height);
+					ovLayer.clear();
 
 					// Draw selected image
 					if (state.selected) {


### PR DESCRIPTION
We finally have some working (?) dynamic canvas scaling. For now, uses buttons to scale the canvas manually. It has some of the black magic everyone loves, and messing with prototypes (which is okay, I think. This is an end-user application and not a lib, and changes only affect canvases with the .origin property set on its context.).

But the good thing of using this approach is that "most" code didn't change much, and if you just develop your tools using world coordinates as normal, everything should work fine. Hard-coded coordinates have no more meaning practically, not even (0, 0) for the layer canvases, so for these particular uses you will have to use the <fn>Root functions, like `drawImageRoot`, or use utility layer functions such as layer.clear().

So, basically:
 - The black magic makes coding decently easy (no dealing with coordinate transforms)
 - The black magic makes history function properly after canvas scale, not requiring any changes to the history entries themselves
 - The black magic is kind of seamless, automatically drawing correctly from canvases to canvases in a way that supports canvas with various origins.
 - The black magic makes things stay in the same place they were before (things on 0, 0 continue in 0, 0; things on 35, 7 continue on 35, 7)
 - The black magic makes negative coordinates valid on the canvas.

Initially, I was trying to use translate() transform and other transformation matrices. But some things (drawImage did not take translate into account when sourcing; same as getImageData and putImageData) were making this a painful transition.

So, this is the black magic commit. If you find any problems during testing (I would be surprised if there aren't any), please open an issue, so I can give this a look.

@zero01101 I don't know what you were expecting, but I guess it may be this.

Signed-off-by: Victor Seiji Hariki <victorseijih@gmail.com>