### PR TITLE
General usability fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,6 +318,7 @@
 			type="text/javascript"></script>
 
 		<!-- Content -->
+		<script src="js/global.js" type="text/javascript"></script>
 		<script src="js/prompt.js" type="text/javascript"></script>
 		<script src="js/index.js" type="text/javascript"></script>
 

--- a/js/global.js
+++ b/js/global.js
@@ -16,4 +16,7 @@ const global = {
 	get connection() {
 		return this._connection;
 	},
+
+	// If there is a selected input
+	hasActiveInput: false,
 };

--- a/js/global.js
+++ b/js/global.js
@@ -1,0 +1,19 @@
+/**
+ * Stores global variables without polluting the global namespace.
+ */
+
+const global = {
+	// Connection
+	_connection: "offline",
+	set connection(v) {
+		this._connection = v;
+
+		toolbar &&
+			toolbar.currentTool &&
+			toolbar.currentTool.state.redraw &&
+			toolbar.currentTool.state.redraw();
+	},
+	get connection() {
+		return this._connection;
+	},
+};

--- a/js/index.js
+++ b/js/index.js
@@ -188,6 +188,7 @@ function startup() {
 }
 
 function setFixedHost(h, changePromptMessage) {
+	console.info(`[index] Fixed host to '${h}'`);
 	const hostInput = document.getElementById("host");
 	host = h;
 	hostInput.value = h;

--- a/js/initalize/layers.populate.js
+++ b/js/initalize/layers.populate.js
@@ -242,8 +242,27 @@ mouse.registerContext(
 		ctx.coords.pos.x = Math.round(layerCoords.x);
 		ctx.coords.pos.y = Math.round(layerCoords.y);
 	},
-	{target: imageCollection.inputElement}
+	{
+		target: imageCollection.inputElement,
+		validate: (evn) => {
+			if (!global.hasActiveInput || evn.type === "mousemove") return true;
+			return false;
+		},
+	}
 );
+
+// Redraw on active input state change
+(() => {
+	mouse.listen.window.onany.on((evn) => {
+		const activeInput = DOM.hasActiveInput();
+		if (global.hasActiveInput !== activeInput) {
+			global.hasActiveInput = activeInput;
+			toolbar.currentTool &&
+				toolbar.currentTool.state.redraw &&
+				toolbar.currentTool.state.redraw();
+		}
+	});
+})();
 
 mouse.listen.window.onwheel.on((evn) => {
 	if (evn.evn.ctrlKey) {

--- a/js/initalize/layers.populate.js
+++ b/js/initalize/layers.populate.js
@@ -20,20 +20,25 @@ const imageCollection = layers.registerCollection(
 
 const bgLayer = imageCollection.registerLayer("bg", {
 	name: "Background",
+	category: "background",
 });
 const imgLayer = imageCollection.registerLayer("image", {
 	name: "Image",
+	category: "image",
 	ctxOptions: {desynchronized: true},
 });
 const maskPaintLayer = imageCollection.registerLayer("mask", {
 	name: "Mask Paint",
+	category: "mask",
 	ctxOptions: {desynchronized: true},
 });
 const ovLayer = imageCollection.registerLayer("overlay", {
 	name: "Overlay",
+	category: "display",
 });
 const debugLayer = imageCollection.registerLayer("debug", {
 	name: "Debug Layer",
+	category: "display",
 });
 
 const imgCanvas = imgLayer.canvas; // where dreams go

--- a/js/lib/input.d.js
+++ b/js/lib/input.d.js
@@ -42,6 +42,7 @@
  * An object for mouse event listeners
  *
  * @typedef MouseListenerContext
+ * @property {Observer} onany A listener for any mouse events
  * @property {Observer} onmousemove A mouse move handler
  * @property {Observer} onwheel A mouse wheel handler
  * @property {Record<string, MouseListenerBtnContext>} btn Button handlers
@@ -67,6 +68,7 @@
  * @property {ContextMoveTransformer} onmove The coordinate transform callback
  * @property {(evn) => void} onany A function to be run on any event
  * @property {?HTMLElement} target The target
+ * @property {(evn) => boolean} validate A function to be check if we will process an event
  * @property {MouseCoordContext} coords Coordinates object
  * @property {MouseListenerContext} listen Listeners object
  */

--- a/js/lib/layers.js
+++ b/js/lib/layers.js
@@ -224,9 +224,6 @@ const layers = {
 		// Input element (overlay element for input handling)
 		const inputel = document.createElement("div");
 		inputel.id = `collection-input-${id}`;
-		inputel.addEventListener("mouseover", (evn) => {
-			document.activeElement.blur();
-		});
 		inputel.classList.add("collection-input-overlay");
 		element.appendChild(inputel);
 

--- a/js/lib/layers.js
+++ b/js/lib/layers.js
@@ -340,6 +340,7 @@ const layers = {
 				 * @param {object} options
 				 * @param {string} options.name
 				 * @param {?BoundingBox} options.bb
+				 * @param {string} [options.category]
 				 * @param {{w: number, h: number}} options.resolution
 				 * @param {?string} options.group
 				 * @param {object} options.after
@@ -361,6 +362,9 @@ const layers = {
 							w: collection.size.w,
 							h: collection.size.h,
 						},
+
+						// Category of the layer
+						category: null,
 
 						// Resolution for layer
 						resolution: null,
@@ -451,6 +455,7 @@ const layers = {
 							key,
 							name: options.name,
 							full,
+							category: options.category,
 
 							state: new Proxy(
 								{visible: true},
@@ -492,6 +497,10 @@ const layers = {
 
 							get origin() {
 								return this._collection.origin;
+							},
+
+							get hidden() {
+								return !this.state.visible;
 							},
 
 							/** Our canvas */

--- a/js/lib/util.js
+++ b/js/lib/util.js
@@ -106,9 +106,9 @@ class Observer {
 	 * Sends a message to all observers
 	 *
 	 * @param {T} msg The message to send to the observers
+	 * @param {any} state The initial state
 	 */
-	async emit(msg) {
-		const state = {};
+	async emit(msg, state = {}) {
 		const promises = [];
 		for (const {handler, wait} of this._handlers) {
 			const run = async () => {
@@ -125,6 +125,25 @@ class Observer {
 		}
 
 		return Promise.all(promises);
+	}
+}
+
+/**
+ * Static DOM utility functions
+ */
+class DOM {
+	static inputTags = new Set(["input", "textarea"]);
+
+	/**
+	 * Checks if there is an active input
+	 *
+	 * @returns Whether there is currently an active input
+	 */
+	static hasActiveInput() {
+		return (
+			document.activeElement &&
+			this.inputTags.has(document.activeElement.tagName.toLowerCase())
+		);
 	}
 }
 

--- a/js/ui/floating/layers.js
+++ b/js/ui/floating/layers.js
@@ -313,11 +313,9 @@ const uil = {
 		const layers = imageCollection._layers;
 
 		layers.reduceRight((_, layer) => {
-			console.debug(layer.name, layer.category, layer.hidden);
 			if (categories.has(layer.category) && !layer.hidden)
 				ctx.drawImage(layer.canvas, bb.x, bb.y, bb.w, bb.h, 0, 0, bb.w, bb.h);
 		});
-		console.debug("END");
 
 		return canvas;
 	},

--- a/js/ui/floating/layers.js
+++ b/js/ui/floating/layers.js
@@ -3,10 +3,17 @@
  */
 
 const uil = {
+	/** @type {Observer<{uilayer: UILayer}>} */
+	onactive: new Observer(),
+
 	_ui_layer_list: document.getElementById("layer-list"),
 	layers: [],
 	_active: null,
 	set active(v) {
+		this.onactive.emit({
+			uilayer: v,
+		});
+
 		Array.from(this._ui_layer_list.children).forEach((child) => {
 			child.classList.remove("active");
 		});
@@ -188,6 +195,7 @@ const uil = {
 	_addLayer(group, name) {
 		const layer = imageCollection.registerLayer(null, {
 			name,
+			category: "user",
 			after:
 				(this.layers.length > 0 && this.layers[this.layers.length - 1].layer) ||
 				bgLayer,
@@ -285,11 +293,13 @@ const uil = {
 	 * @param {BoundingBox} bb The bouding box to get visible data from
 	 * @param {object} [options] Options
 	 * @param {boolean} [options.includeBg=false] Whether to include the background
+	 * @param {string[]} [options.categories] Categories of layers to consider visible
 	 * @returns {HTMLCanvasElement}	The canvas element containing visible image data
 	 */
 	getVisible(bb, options = {}) {
 		defaultOpt(options, {
 			includeBg: false,
+			categories: ["user", "image"],
 		});
 
 		const canvas = document.createElement("canvas");
@@ -297,22 +307,17 @@ const uil = {
 
 		canvas.width = bb.w;
 		canvas.height = bb.h;
-		if (options.includeBg)
-			ctx.drawImage(bgLayer.canvas, bb.x, bb.y, bb.w, bb.h, 0, 0, bb.w, bb.h);
-		this.layers.forEach((layer) => {
-			if (!layer.hidden)
-				ctx.drawImage(
-					layer.layer.canvas,
-					bb.x,
-					bb.y,
-					bb.w,
-					bb.h,
-					0,
-					0,
-					bb.w,
-					bb.h
-				);
+
+		const categories = new Set(options.categories);
+		if (options.includeBg) categories.add("background");
+		const layers = imageCollection._layers;
+
+		layers.reduceRight((_, layer) => {
+			console.debug(layer.name, layer.category, layer.hidden);
+			if (categories.has(layer.category) && !layer.hidden)
+				ctx.drawImage(layer.canvas, bb.x, bb.y, bb.w, bb.h, 0, 0, bb.w, bb.h);
 		});
+		console.debug("END");
 
 		return canvas;
 	},
@@ -336,6 +341,7 @@ commands.createCommand(
 
 			const layer = imageCollection.registerLayer(null, {
 				name,
+				category: "user",
 				after:
 					(uil.layers.length > 0 && uil.layers[uil.layers.length - 1].layer) ||
 					bgLayer,

--- a/js/ui/tool/colorbrush.js
+++ b/js/ui/tool/colorbrush.js
@@ -62,16 +62,19 @@ const colorBrushTool = () =>
 
 			state.drawLayer = imageCollection.registerLayer(null, {
 				after: imgLayer,
+				category: "display",
 				ctxOptions: {willReadFrequently: true},
 			});
 			state.drawLayer.canvas.style.filter = "opacity(70%)";
 			state.eraseLayer = imageCollection.registerLayer(null, {
 				after: imgLayer,
+				category: "processing",
 				ctxOptions: {willReadFrequently: true},
 			});
 			state.eraseLayer.hide();
 			state.eraseBackup = imageCollection.registerLayer(null, {
 				after: imgLayer,
+				category: "processing",
 			});
 			state.eraseBackup.hide();
 

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -1228,7 +1228,7 @@ const dreamTool = () =>
 						y += snap(evn.y, 0, 64);
 					}
 
-					state.erasePrevReticle = _tool._cursor_draw(x, y);
+					state.erasePrevCursor = _tool._cursor_draw(x, y);
 
 					if (state.selection.exists) {
 						const bb = state.selection.bb;
@@ -1600,7 +1600,7 @@ const img2imgTool = () =>
 						y += snap(evn.y, 0, 64);
 					}
 
-					state.erasePrevReticle = _tool._cursor_draw(x, y);
+					state.erasePrevCursor = _tool._cursor_draw(x, y);
 
 					// Resolution
 					let bb = null;

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -24,6 +24,7 @@ const _monitorProgress = (bb, oncheck = null) => {
 	// Get temporary layer to draw progress bar
 	const layer = imageCollection.registerLayer(null, {
 		bb: expanded,
+		category: "display",
 	});
 	layer.canvas.style.opacity = "70%";
 
@@ -293,6 +294,7 @@ const _generate = async (endpoint, request, bb, options = {}) => {
 	// Layer for the images
 	const layer = imageCollection.registerLayer(null, {
 		after: maskPaintLayer,
+		category: "display",
 	});
 
 	const redraw = (url = images[at]) => {
@@ -1250,6 +1252,8 @@ const dreamTool = () =>
 								),
 							},
 							{
+								toolTextStyle:
+									global.connection === "online" ? "#FFF5" : "#F555",
 								reticleStyle: state.selection.inside ? "#F55" : "#FFF",
 								sizeTextStyle: style,
 							}
@@ -1277,6 +1281,7 @@ const dreamTool = () =>
 							h: stableDiffusionData.height,
 						},
 						{
+							toolTextStyle: global.connection === "online" ? "#FFF5" : "#F555",
 							sizeTextStyle: style,
 						}
 					);
@@ -1305,8 +1310,19 @@ const dreamTool = () =>
 						w: stableDiffusionData.width,
 						h: stableDiffusionData.height,
 					};
-					dream_generate_callback(bb, resolution, state);
+
+					if (global.connection === "online") {
+						dream_generate_callback(bb, resolution, state);
+					} else {
+						const stop = march(bb, {
+							title: "offline",
+							titleStyle: "#F555",
+							style: "#F55",
+						});
+						setTimeout(stop, 2000);
+					}
 					state.selection.deselect();
+					state.redraw();
 				};
 				state.erasecb = (evn, estate) => {
 					if (state.selection.exists) {
@@ -1613,6 +1629,8 @@ const img2imgTool = () =>
 								),
 							},
 							{
+								toolTextStyle:
+									global.connection === "online" ? "#FFF5" : "#F555",
 								reticleStyle: state.selection.inside ? "#F55" : "#FFF",
 								sizeTextStyle: style,
 							}
@@ -1642,6 +1660,8 @@ const img2imgTool = () =>
 							"Img2Img",
 							{w: request.width, h: request.height},
 							{
+								toolTextStyle:
+									global.connection === "online" ? "#FFF5" : "#F555",
 								sizeTextStyle: style,
 							}
 						);
@@ -1766,7 +1786,16 @@ const img2imgTool = () =>
 						w: stableDiffusionData.width,
 						h: stableDiffusionData.height,
 					};
-					dream_img2img_callback(bb, resolution, state);
+					if (global.connection === "online") {
+						dream_img2img_callback(bb, resolution, state);
+					} else {
+						const stop = march(bb, {
+							title: "offline",
+							titleStyle: "#F555",
+							style: "#F55",
+						});
+						setTimeout(stop, 2000);
+					}
 					state.selection.deselect();
 					state.redraw();
 				};

--- a/js/ui/tool/generic.js
+++ b/js/ui/tool/generic.js
@@ -14,7 +14,7 @@ const _tool = {
 	 * @param {string} [style.genSizeTextStyle = "#FFF5"] Style of the text for diplaying generation size
 	 * @param {string} [style.toolTextStyle = "#FFF5"] Style of the text for the tool name
 	 * @param {number} [style.reticleWidth = 1] Width of the line of the reticle
-	 * @param {string} [style.reticleStyle = "#FFF"] Style of the line of the reticle
+	 * @param {string} [style.reticleStyle] Style of the line of the reticle
 	 *
 	 * @returns A function that erases this reticle drawing
 	 */
@@ -24,7 +24,7 @@ const _tool = {
 			genSizeTextStyle: "#FFF5",
 			toolTextStyle: "#FFF5",
 			reticleWidth: 1,
-			reticleStyle: "#FFF",
+			reticleStyle: global.hasActiveInput ? "#BBF" : "#FFF",
 		});
 
 		const bbvp = {
@@ -110,14 +110,14 @@ const _tool = {
 	 * @param {number} y Y world coordinate of the cursor
 	 * @param {object} style Style of the lines of the cursor
 	 * @param {string} [style.width = 3] Line width of the lines of the cursor
-	 * @param {string} [style.style = "#FFF5"] Stroke style of the lines of the cursor
+	 * @param {string} [style.style] Stroke style of the lines of the cursor
 	 *
 	 * @returns A function that erases this cursor drawing
 	 */
 	_cursor_draw(x, y, style = {}) {
 		defaultOpt(style, {
 			width: 3,
-			style: "#FFF5",
+			style: global.hasActiveInput ? "#BBF5" : "#FFF5",
 		});
 		const vpc = viewport.canvasToView(x, y);
 

--- a/js/ui/tool/select.js
+++ b/js/ui/tool/select.js
@@ -206,6 +206,7 @@ const selectTransformTool = () =>
 				state.movecb = (evn) => {
 					ovLayer.clear();
 					uiCtx.clearRect(0, 0, uiCanvas.width, uiCanvas.height);
+					state.erasePrevCursor && state.erasePrevCursor();
 					imageCollection.inputElement.style.cursor = "auto";
 					state.lastMouseTarget = evn.target;
 					state.lastMouseMove = evn;
@@ -355,15 +356,7 @@ const selectTransformTool = () =>
 					}
 
 					// Draw current cursor location
-					uiCtx.lineWidth = 3;
-					uiCtx.strokeStyle = "#FFF";
-
-					uiCtx.beginPath();
-					uiCtx.moveTo(vpc.x, vpc.y + 10);
-					uiCtx.lineTo(vpc.x, vpc.y - 10);
-					uiCtx.moveTo(vpc.x + 10, vpc.y);
-					uiCtx.lineTo(vpc.x - 10, vpc.y);
-					uiCtx.stroke();
+					state.erasePrevCursor = _tool._cursor_draw(x, y);
 
 					uiCtx.restore();
 				};

--- a/js/ui/tool/stamp.js
+++ b/js/ui/tool/stamp.js
@@ -151,17 +151,22 @@ const stampTool = () =>
 							);
 							const resourceWrapper = document.createElement("div");
 							resourceWrapper.id = `resource-${resource.id}`;
+							resourceWrapper.title = resource.name;
 							resourceWrapper.classList.add("resource", "list-item");
 							const resourceTitle = document.createElement("input");
 							resourceTitle.value = resource.name;
-							resourceTitle.title = resource.name;
 							resourceTitle.style.pointerEvents = "none";
 							resourceTitle.addEventListener("change", () => {
 								resource.name = resourceTitle.value;
 								resource.dirty = true;
-								resourceTitle.title = resourceTitle.value;
+								resourceWrapper.title = resourceTitle.value;
 
 								syncResources();
+							});
+							resourceTitle.addEventListener("keyup", function (event) {
+								if (event.key === "Enter") {
+									resourceTitle.blur();
+								}
 							});
 
 							resourceTitle.addEventListener("blur", () => {
@@ -301,6 +306,7 @@ const stampTool = () =>
 
 					const vpc = viewport.canvasToView(x, y);
 					uiCtx.clearRect(0, 0, uiCanvas.width, uiCanvas.height);
+					state.erasePrevCursor && state.erasePrevCursor();
 
 					uiCtx.save();
 
@@ -314,16 +320,7 @@ const stampTool = () =>
 					}
 
 					// Draw current cursor location
-					uiCtx.lineWidth = 3;
-					uiCtx.strokeStyle = "#FFF";
-
-					uiCtx.beginPath();
-					uiCtx.moveTo(vpc.x, vpc.y + 10);
-					uiCtx.lineTo(vpc.x, vpc.y - 10);
-					uiCtx.moveTo(vpc.x + 10, vpc.y);
-					uiCtx.lineTo(vpc.x - 10, vpc.y);
-					uiCtx.stroke();
-
+					state.erasePrevCursor = _tool._cursor_draw(x, y);
 					uiCtx.restore();
 				};
 


### PR DESCRIPTION
Fixes sampler didn't load correctly, marquee tool now supports multiple layers appropriately (can move selections from each layer, and applies changes correctly). Also added ghost peek to marquee when editing bottom layers.

Makes text fields less finicky. Now, if a text field is selected, canvas must be clicked once to focus it again.