### PR TITLE
sigh

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=134f3eb" type="text/javascript"></script>
+		<script src="js/index.js?v=bc49f7d" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=13b37c8" type="text/javascript"></script>
+		<script src="js/index.js?v=a30c20a" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=bc49f7d" type="text/javascript"></script>
+		<script src="js/index.js?v=e28f84d" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"

--- a/index.html
+++ b/index.html
@@ -339,7 +339,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=eae1998" type="text/javascript"></script>
+		<script src="js/index.js?v=ddaf955" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"
@@ -353,7 +353,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=6d1e673" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=51b08d9" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -353,7 +353,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=d6ad22c" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=45cb85f" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=e28f84d" type="text/javascript"></script>
+		<script src="js/index.js?v=13b37c8" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 					<div id="hrFixScale"></div>
 					<label id="hrFixLabel">Choose HRfix upscaler</label>
 					<div id="hrFixUpscaler"></div>
+					<div id="hrDenoising"></div>
 					<input
 						type="checkbox"
 						id="cbxRestoreFaces"
@@ -189,7 +190,7 @@
 					<br />
 					<span id="version">
 						<a href="https://github.com/zero01101/openOutpaint" target="_blank">
-							Alpha release v0.0.12.3
+							Alpha release v0.0.12.5
 						</a>
 					</span>
 					<br />
@@ -339,7 +340,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=ddaf955" type="text/javascript"></script>
+		<script src="js/index.js?v=34970e7" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
 				<div class="ui separator"></div>
 				<iframe
 					id="page-overlay"
-					src="pages/configuration.html?v=ae8af5d"></iframe>
+					src="pages/configuration.html?v=3d710ce"></iframe>
 			</div>
 		</div>
 
@@ -353,7 +353,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=51b08d9" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=d6ad22c" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=34970e7" type="text/javascript"></script>
+		<script src="js/index.js?v=9056c91" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"

--- a/index.html
+++ b/index.html
@@ -98,9 +98,11 @@
 						step="1" />
 					<br />
 					<input type="checkbox" id="cbxHRFix" onchange="changeHiResFix()" />
-					<label for="cbxHRFix">Auto txt2img HRfix</label>
+					<label for="cbxHRFix">Apply txt2img HRfix</label>
 					<br />
-					<div id="hrFixLock"></div>
+					<div id="hrFixScale"></div>
+					<label id="hrFixLabel">Choose HRfix upscaler</label>
+					<div id="hrFixUpscaler"></div>
 					<input
 						type="checkbox"
 						id="cbxRestoreFaces"
@@ -118,27 +120,27 @@
 					<div id="cfgScale"></div>
 					<div id="batchSize"></div>
 					<div id="batchCount"></div>
+					<label for="maskBlur">Mask blur:</label>
+					<span id="maskBlurText"></span>
+					<br />
+					<input
+						type="number"
+						id="maskBlur"
+						name="maskBlur"
+						min="0"
+						max="256"
+						value="0"
+						step="1"
+						onchange="changeMaskBlur()" />
+					<br />
+					<input
+						type="checkbox"
+						id="cbxSmooth"
+						checked
+						onchange="changeSmoothRendering()" />
+					<label for="cbxSmooth">Smooth Rendering</label>
 				</div>
-				<!-- Unsectioned -->
-				<label for="maskBlur">Mask blur:</label>
-				<span id="maskBlurText"></span>
-				<br />
-				<input
-					type="number"
-					id="maskBlur"
-					name="maskBlur"
-					min="0"
-					max="256"
-					value="0"
-					step="1"
-					onchange="changeMaskBlur()" />
-				<br />
-				<input
-					type="checkbox"
-					id="cbxSmooth"
-					checked
-					onchange="changeSmoothRendering()" />
-				<label for="cbxSmooth">Smooth Rendering</label>
+
 				<!-- Save/load image section -->
 				<button type="button" class="collapsible">Save/Upscaling</button>
 				<div class="content">
@@ -337,7 +339,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=133b74b" type="text/javascript"></script>
+		<script src="js/index.js?v=eae1998" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"
@@ -351,7 +353,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=832aa62" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=6d1e673" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=9056c91" type="text/javascript"></script>
+		<script src="js/index.js?v=134f3eb" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"

--- a/js/index.js
+++ b/js/index.js
@@ -560,6 +560,7 @@ const hrFixUpscalerAutoComplete = createAutoComplete(
 );
 hrFixUpscalerAutoComplete.onchange.on(({value}) => {
 	stableDiffusionData.hr_upscaler = value;
+	localStorage.setItem(`openoutpaint/hr_upscaler`, value);
 });
 
 const resSlider = makeSlider(
@@ -647,7 +648,7 @@ makeSlider(
 	"denoising_strength",
 	0.0,
 	1.0,
-	0.1,
+	0.05,
 	0.7,
 	0.01
 );
@@ -1103,6 +1104,20 @@ function loadSettings() {
 			? true
 			: localStorage.getItem("openoutpaint/sync_cursor_size") === "true";
 
+	let _hrfix_scale =
+		localStorage.getItem("openoutpaint/hr_scale") === null
+			? 2.0
+			: localStorage.getItem("openoutpaint/hr_scale");
+
+	let _hrfix_upscaler =
+		localStorage.getItem("openoutpaint/hr_upscaler") === null
+			? "None"
+			: localStorage.getItem("openoutpaint/hr_upscaler");
+
+	let _hrfix_denoising =
+		localStorage.getItem("openoutpaint/denoising_strength") === null
+			? 0.7
+			: localStorage.getItem("openoutpaint/denoising_strength");
 	// set the values into the UI
 	document.getElementById("maskBlur").value = Number(_mask_blur);
 	document.getElementById("seed").value = Number(_seed);
@@ -1110,6 +1125,9 @@ function loadSettings() {
 	document.getElementById("cbxRestoreFaces").checked = Boolean(_restore_faces);
 	document.getElementById("cbxSyncCursorSize").checked =
 		Boolean(_sync_cursor_size);
+	document.getElementById("hrFixScale").value = Number(_hrfix_scale);
+	document.getElementById("hrFixUpscaler").value = Number(_hrfix_upscaler);
+	document.getElementById("hrDenoising").value = Number(_hrfix_denoising);
 }
 
 imageCollection.element.addEventListener(

--- a/js/index.js
+++ b/js/index.js
@@ -641,6 +641,17 @@ makeSlider(
 	0.1
 );
 
+makeSlider(
+	"HRfix Denoising",
+	document.getElementById("hrDenoising"),
+	"denoising_strength",
+	0.0,
+	1.0,
+	0.1,
+	0.7,
+	0.01
+);
+
 function changeMaskBlur() {
 	stableDiffusionData.mask_blur = parseInt(
 		document.getElementById("maskBlur").value
@@ -661,15 +672,18 @@ function changeHiResFix() {
 	var hrfSlider = document.getElementById("hrFixScale");
 	var hrfOpotions = document.getElementById("hrFixUpscaler");
 	var hrfLabel = document.getElementById("hrFixLabel");
+	var hrfDenoiseSlider = document.getElementById("hrDenoising");
 	if (stableDiffusionData.enable_hr) {
 		hrfSlider.classList.remove("invisible");
 		hrfOpotions.classList.remove("invisible");
 		hrfLabel.classList.remove("invisible");
+		hrfDenoiseSlider.classList.remove("invisible");
 		//state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.add("invisible");
 	} else {
 		hrfSlider.classList.add("invisible");
 		hrfOpotions.classList.add("invisible");
 		hrfLabel.classList.add("invisible");
+		hrfDenoiseSlider.classList.add("invisible");
 		//state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.remove("invisible");
 	}
 }

--- a/js/index.js
+++ b/js/index.js
@@ -343,6 +343,12 @@ async function testHostConnection() {
 			const response = await fetch(
 				document.getElementById("host").value + "/sdapi/v1/options"
 			);
+			const optionsdata = await response.json();
+			if (optionsdata["use_scale_latent_for_hires_fix"]) {
+				const message = `You are using an outdated version of A1111 webUI.\nThe HRfix options will not work until you update to at least commit ef27a18\n(https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/ef27a18b6b7cb1a8eebdc9b2e88d25baf2c2414d)\nor newer.`;
+				console.error(message);
+				alert(message);
+			}
 			switch (response.status) {
 				case 200: {
 					setConnectionStatus("online");

--- a/js/index.js
+++ b/js/index.js
@@ -797,7 +797,10 @@ async function getUpscalers() {
 		});
 
 		upscalerAutoComplete.value = upscalers[0];
-		hrFixUpscalerAutoComplete.value = upscalersPlusNone[0];
+		hrFixUpscalerAutoComplete.value =
+			localStorage.getItem("openoutpaint/hr_upscaler") === null
+				? "None"
+				: localStorage.getItem("openoutpaint/hr_upscaler");
 	} catch (e) {
 		console.warn("[index] Failed to fetch upscalers:");
 		console.warn(e);
@@ -1109,11 +1112,6 @@ function loadSettings() {
 			? 2.0
 			: localStorage.getItem("openoutpaint/hr_scale");
 
-	let _hrfix_upscaler =
-		localStorage.getItem("openoutpaint/hr_upscaler") === null
-			? "None"
-			: localStorage.getItem("openoutpaint/hr_upscaler");
-
 	let _hrfix_denoising =
 		localStorage.getItem("openoutpaint/denoising_strength") === null
 			? 0.7
@@ -1126,7 +1124,6 @@ function loadSettings() {
 	document.getElementById("cbxSyncCursorSize").checked =
 		Boolean(_sync_cursor_size);
 	document.getElementById("hrFixScale").value = Number(_hrfix_scale);
-	document.getElementById("hrFixUpscaler").value = Number(_hrfix_upscaler);
 	document.getElementById("hrDenoising").value = Number(_hrfix_denoising);
 }
 

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -1387,18 +1387,6 @@ const dreamTool = () =>
 						h: stableDiffusionData.height,
 					};
 
-					//hacky set non-square auto hrfix values
-					let hrLockPx =
-						localStorage.getItem("openoutpaint/hr_fix_lock_px") ?? 0;
-					stableDiffusionData.firstphase_height =
-						hrLockPx == 0 || resolution.h / 2 <= hrLockPx
-							? resolution.h / 2
-							: hrLockPx;
-					stableDiffusionData.firstphase_width =
-						hrLockPx == 0 || resolution.w / 2 <= hrLockPx
-							? resolution.w / 2
-							: hrLockPx;
-
 					if (global.connection === "online") {
 						dream_generate_callback(bb, resolution, state);
 					} else {
@@ -1492,8 +1480,14 @@ const dreamTool = () =>
 								state.ctxmenu.keepUnmaskedBlurSlider.classList.remove(
 									"invisible"
 								);
+								state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.add(
+									"invisible"
+								);
 							} else {
 								state.ctxmenu.keepUnmaskedBlurSlider.classList.add("invisible");
+								state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.remove(
+									"invisible"
+								);
 							}
 						}
 					).label;
@@ -1510,6 +1504,12 @@ const dreamTool = () =>
 							textStep: 1,
 						}
 					).slider;
+
+					state.ctxmenu.keepUnmaskedBlurSliderLinebreak =
+						document.createElement("br");
+					state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.add(
+						"invisible"
+					);
 
 					// Preserve Brushed Masks Checkbox
 					state.ctxmenu.preserveMasksLabel = _toolbar_input.checkbox(
@@ -1552,6 +1552,7 @@ const dreamTool = () =>
 				menu.appendChild(document.createElement("br"));
 				menu.appendChild(state.ctxmenu.keepUnmaskedLabel);
 				menu.appendChild(state.ctxmenu.keepUnmaskedBlurSlider);
+				menu.appendChild(state.ctxmenu.keepUnmaskedBlurSliderLinebreak);
 				menu.appendChild(state.ctxmenu.preserveMasksLabel);
 				menu.appendChild(document.createElement("br"));
 				menu.appendChild(state.ctxmenu.overMaskPxLabel);

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -130,6 +130,22 @@ const _dream = async (endpoint, request) => {
 	let data = null;
 	try {
 		generating = true;
+		if (
+			endpoint == "txt2img" &&
+			request.enable_hr &&
+			localStorage.getItem("openoutpaint/settings.hrfix-liar") == "true"
+		) {
+			/**
+			 * try and make the new HRfix method useful for our purposes
+			 * since it now returns an image that's been upscaled x the hr_scale parameter,
+			 * we cheekily lie to SD and tell it that the original dimensions are _divided_
+			 * by the scale factor so it returns something about the same size as we wanted initially
+			 */
+			var newWidth = Math.floor(request.width / request.hr_scale);
+			var newHeight = Math.floor(request.height / request.hr_scale);
+			request.width = newWidth;
+			request.height = newHeight;
+		}
 		const response = await fetch(apiURL, {
 			method: "POST",
 			headers: {

--- a/pages/configuration.html
+++ b/pages/configuration.html
@@ -84,6 +84,10 @@
 				step="0.1"
 				value="30.0" />
 		</label>
+		<label style="display: flex">
+			Lie to HRfix:
+			<input id="hrfix-liar" class="canvas-size-input" type="checkbox" />
+		</label>
 		<p>Refresh the page to apply settings.</p>
 
 		<script>
@@ -92,6 +96,7 @@
 			const maxSteps = document.getElementById("max-steps");
 			const minCfg = document.getElementById("min-cfg");
 			const maxCfg = document.getElementById("max-cfg");
+			const hrfixLiar = document.getElementById("hrfix-liar");
 
 			function writeToLocalStorage() {
 				localStorage.setItem(
@@ -105,6 +110,10 @@
 				localStorage.setItem("openoutpaint/settings.max-steps", maxSteps.value);
 				localStorage.setItem("openoutpaint/settings.min-cfg", minCfg.value);
 				localStorage.setItem("openoutpaint/settings.max-cfg", maxCfg.value);
+				localStorage.setItem(
+					"openoutpaint/settings.hrfix-liar",
+					hrfixLiar.checked
+				);
 			}
 
 			// Loads values from local storage
@@ -118,6 +127,8 @@
 				localStorage.getItem("openoutpaint/settings.min-cfg") || -1;
 			maxCfg.value =
 				localStorage.getItem("openoutpaint/settings.max-cfg") || 30;
+			hrfixLiar.checked =
+				localStorage.getItem("openoutpaint/settings.hrfix-liar") || true;
 
 			writeToLocalStorage();
 
@@ -126,6 +137,7 @@
 			maxSteps.onchange = writeToLocalStorage;
 			minCfg.onchange = writeToLocalStorage;
 			maxCfg.onchange = writeToLocalStorage;
+			hrfixLiar.onchange = writeToLocalStorage;
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
welp ok
seems A1111 has had a [fairly extensive](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/ef27a18b6b7cb1a8eebdc9b2e88d25baf2c2414d) HRfix rework that not only completely negates that nifty HRfix lock px slider entirely, [but seems to have caused wild havoc in the masses](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6219).  

this commit completely f&%#$ng reworks the entirety of the previous HRfix system to comply with the new "yeah it's just an upscaler" expectations, does some ugly garbo to the upscalers list routine because we _absolutely must_ have "none" in there as well as completely broken and non-functional "latent" and "latent (nearest)" which aren't even returned in the stupidly non-working-right api call to retrieve upscalers anyway asdl;fkjgas;dkljasdlfgk

yeah i'm a bit frustrated can you tell