### PR TITLE
Generally fix black when outpainting using some firefox addons

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,7 +354,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=fd6a77e" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=a68bed9" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=832aa62" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=fd6a77e" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -816,16 +816,21 @@ const dream_generate_callback = async (bb, resolution, state) => {
 		bbCanvas.height = bb.h;
 		const bbCtx = bbCanvas.getContext("2d");
 
-		const reqCanvas = document.createElement("canvas");
-		reqCanvas.width = request.width;
-		reqCanvas.height = request.height;
-		const reqCtx = reqCanvas.getContext("2d");
+		const maskCanvas = document.createElement("canvas");
+		maskCanvas.width = request.width;
+		maskCanvas.height = request.height;
+		const maskCtx = maskCanvas.getContext("2d");
+
+		const initCanvas = document.createElement("canvas");
+		initCanvas.width = request.width;
+		initCanvas.height = request.height;
+		const initCtx = initCanvas.getContext("2d");
 
 		bbCtx.fillStyle = "#000F";
 
 		// Get init image
-		reqCtx.fillRect(0, 0, request.width, request.height);
-		reqCtx.drawImage(
+		initCtx.fillRect(0, 0, request.width, request.height);
+		initCtx.drawImage(
 			visibleCanvas,
 			0,
 			0,
@@ -836,7 +841,7 @@ const dream_generate_callback = async (bb, resolution, state) => {
 			request.width,
 			request.height
 		);
-		request.init_images = [reqCanvas.toDataURL()];
+		request.init_images = [initCanvas.toDataURL()];
 
 		// Get mask image
 		bbCtx.fillStyle = "#000F";
@@ -890,8 +895,8 @@ const dream_generate_callback = async (bb, resolution, state) => {
 		bbCtx.fillStyle = "#FFFF";
 		bbCtx.fillRect(0, 0, bb.w, bb.h);
 
-		reqCtx.clearRect(0, 0, reqCanvas.width, reqCanvas.height);
-		reqCtx.drawImage(
+		maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
+		maskCtx.drawImage(
 			bbCanvas,
 			0,
 			0,
@@ -902,7 +907,7 @@ const dream_generate_callback = async (bb, resolution, state) => {
 			request.width,
 			request.height
 		);
-		request.mask = reqCanvas.toDataURL();
+		request.mask = maskCanvas.toDataURL();
 
 		// Dream
 		_generate("img2img", request, bb, {


### PR DESCRIPTION
For some reason, when using some extensions, Firefox just bugs out the context after running a toDataURL. We now create a separate canvas for mask drawing, avoiding the issue altogether.

Should mostly fix https://github.com/zero01101/openOutpaint-webUI-extension/issues/3 even with addons installed.

