### PR TITLE
fix leave-page alert

### DIFF
--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -1,7 +1,6 @@
 let blockNewImages = false;
 let generationQueue = [];
 let generationAreas = new Set();
-let generating = false;
 
 /**
  * Starts progress monitoring bar
@@ -76,6 +75,17 @@ const _monitorProgress = (bb, oncheck = null) => {
 	};
 };
 
+let busy = false
+const generating = (val) => {
+	console.log('GENERATING', val)
+	busy = val
+	if (busy) {
+		window.onbeforeunload = async () => { await sendInterrupt(); };
+	}	else {
+		window.onbeforeunload = null
+	}
+}
+
 /**
  * Starts a dream
  *
@@ -129,7 +139,7 @@ const _dream = async (endpoint, request) => {
 	/** @type {StableDiffusionResponse} */
 	let data = null;
 	try {
-		generating = true;
+		generating(true);
 		if (
 			endpoint == "txt2img" &&
 			request.enable_hr &&
@@ -176,7 +186,7 @@ const _dream = async (endpoint, request) => {
 
 		data = await response.json();
 	} finally {
-		generating = false;
+		generating(false);
 	}
 	var responseSubdata = JSON.parse(data.info);
 	var returnData = {
@@ -724,9 +734,7 @@ const _generate = async (endpoint, request, bb, options = {}) => {
 		mouse.listen.world.btn.middle.onclick.clear(onmorehandler);
 		mouse.listen.world.onwheel.clear(onwheelhandler);
 		isDreamComplete = true;
-		if (generating) {
-			sendInterrupt();
-		}
+		generating(false)
 	};
 
 	redraw();
@@ -2205,11 +2213,6 @@ const img2imgTool = () =>
 			shortcut: "I",
 		}
 	);
-
-window.onbeforeunload = async () => {
-	// Stop current generation on page close
-	if (generating) await sendInterrupt();
-};
 
 const sendSeed = (seed) => {
 	stableDiffusionData.seed = document.getElementById("seed").value = seed;

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -77,7 +77,6 @@ const _monitorProgress = (bb, oncheck = null) => {
 
 let busy = false
 const generating = (val) => {
-	console.log('GENERATING', val)
 	busy = val
 	if (busy) {
 		window.onbeforeunload = async () => { await sendInterrupt(); };


### PR DESCRIPTION
dont register global onbefore `onbeforeunload` as it triggers alert **always**  
even if outpaint is not busy, it will always block closing of the page.

and in case of automatic1111 extension, it will block closing of automatic even if openoutpaint tab is not active (and never was)

i've implemented `generate` as function so it takes care of that as needed.
