### PR TITLE
experimental? newer hrfix stuff

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -644,3 +644,9 @@ select > .style-select-option:active {
 .button.tool.active {
 	background-color: rgb(60, 60, 130);
 }
+
+/* Miscellaneous garbage */
+
+.thirdwidth {
+	max-width: 33%;
+}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 		<link href="css/colors.css?v=3f81e80" rel="stylesheet" />
 		<link href="css/icons.css?v=caa702e" rel="stylesheet" />
 
-		<link href="css/index.css?v=69d3b9e" rel="stylesheet" />
+		<link href="css/index.css?v=5b8d4d6" rel="stylesheet" />
 		<link href="css/layers.css?v=b4fbf61" rel="stylesheet" />
 
 		<link href="css/ui/generic.css?v=4b9afe2" rel="stylesheet" />
@@ -100,8 +100,31 @@
 					<input type="checkbox" id="cbxHRFix" onchange="changeHiResFix()" />
 					<label for="cbxHRFix">Apply txt2img HRfix</label>
 					<br />
+					<label class="hrfix">Resize to (>0 overrides scale):</label>
+					<br class="hrfix" />
+					<label for="hrfOutX" class="hrfix">X:</label>
+					<input
+						type="number"
+						id="hr_resize_x"
+						onchange="changeHRFX()"
+						min="0"
+						max="2048"
+						value="0"
+						step="8"
+						class="hrfix thirdwidth" />
+					<label for="hrfOutY" class="hrfix">Y:</label>
+					<input
+						type="number"
+						id="hr_resize_y"
+						onchange="changeHRFY()"
+						min="0"
+						max="2048"
+						value="0"
+						step="8"
+						class="hrfix thirdwidth" />
 					<div id="hrFixScale" class="hrfix"></div>
 					<div id="hrFixLockPx" class="hrfix"></div>
+					<div id="hrFixSteps" class="hrfix"></div>
 					<label id="hrFixLabel" class="hrfix">Choose HRfix upscaler</label>
 					<div id="hrFixUpscaler" class="hrfix"></div>
 					<div id="hrDenoising" class="hrfix"></div>
@@ -323,7 +346,7 @@
 		<script src="js/global.js?v=3a1cde6" type="text/javascript"></script>
 
 		<!-- Base Libs -->
-		<script src="js/lib/util.js?v=7f6847c" type="text/javascript"></script>
+		<script src="js/lib/util.js?v=5838390" type="text/javascript"></script>
 		<script src="js/lib/events.js?v=2ab7933" type="text/javascript"></script>
 		<script src="js/lib/input.js?v=09298ac" type="text/javascript"></script>
 		<script src="js/lib/layers.js?v=a1f8aea" type="text/javascript"></script>
@@ -341,7 +364,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=afc36b6" type="text/javascript"></script>
+		<script src="js/index.js?v=87cef1a" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"
@@ -352,10 +375,10 @@
 
 		<!-- Load Tools -->
 		<script
-			src="js/ui/tool/generic.js?v=2bcd36d"
+			src="js/ui/tool/generic.js?v=f1a19a4"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=1f10ae6" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=0c4379b" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -98,14 +98,16 @@
 						step="1" />
 					<br />
 					<input type="checkbox" id="cbxHRFix" onchange="changeHiResFix()" />
-					<label for="cbxHRFix">Apply txt2img HRfix</label>
+					<label for="cbxHRFix">Apply Txt2Img HRfix</label>
 					<br />
 					<input
 						type="checkbox"
 						id="cbxHRFSquare"
 						onchange="changeHiResSquare()"
 						class="hrfix" />
-					<label for="cbxHRFSquare" class="hrfix">Square Aspect</label>
+					<label for="cbxHRFSquare" class="hrfix">
+						Square Firstpass Aspect
+					</label>
 					<br class="hrfix" />
 					<div id="hrFixScale" class="hrfix"></div>
 					<div id="hrFixLockPx" class="hrfix"></div>
@@ -331,7 +333,7 @@
 		<script src="js/global.js?v=3a1cde6" type="text/javascript"></script>
 
 		<!-- Base Libs -->
-		<script src="js/lib/util.js?v=7f6847c" type="text/javascript"></script>
+		<script src="js/lib/util.js?v=5838390" type="text/javascript"></script>
 		<script src="js/lib/events.js?v=2ab7933" type="text/javascript"></script>
 		<script src="js/lib/input.js?v=09298ac" type="text/javascript"></script>
 		<script src="js/lib/layers.js?v=a1f8aea" type="text/javascript"></script>
@@ -349,7 +351,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=2ac15cc" type="text/javascript"></script>
+		<script src="js/index.js?v=c6539e5" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"
@@ -360,10 +362,10 @@
 
 		<!-- Load Tools -->
 		<script
-			src="js/ui/tool/generic.js?v=2bcd36d"
+			src="js/ui/tool/generic.js?v=f1a19a4"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=5a652c4" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=ac1cedd" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@
 
 		<!-- Content -->
 		<script src="js/prompt.js?v=7a1c68c" type="text/javascript"></script>
-		<script src="js/index.js?v=87cef1a" type="text/javascript"></script>
+		<script src="js/index.js?v=2ac15cc" type="text/javascript"></script>
 
 		<script
 			src="js/ui/floating/history.js?v=fc92d14"
@@ -363,7 +363,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=0c4379b" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=5a652c4" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@
 		<script src="js/global.js?v=3a1cde6" type="text/javascript"></script>
 
 		<!-- Base Libs -->
-		<script src="js/lib/util.js?v=5838390" type="text/javascript"></script>
+		<script src="js/lib/util.js?v=7f6847c" type="text/javascript"></script>
 		<script src="js/lib/events.js?v=2ab7933" type="text/javascript"></script>
 		<script src="js/lib/input.js?v=09298ac" type="text/javascript"></script>
 		<script src="js/lib/layers.js?v=a1f8aea" type="text/javascript"></script>
@@ -375,7 +375,7 @@
 
 		<!-- Load Tools -->
 		<script
-			src="js/ui/tool/generic.js?v=f1a19a4"
+			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
 		<script src="js/ui/tool/dream.js?v=0c4379b" type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -100,28 +100,13 @@
 					<input type="checkbox" id="cbxHRFix" onchange="changeHiResFix()" />
 					<label for="cbxHRFix">Apply txt2img HRfix</label>
 					<br />
-					<label class="hrfix">Resize to (>0 overrides scale):</label>
+					<input
+						type="checkbox"
+						id="cbxHRFSquare"
+						onchange="changeHiResSquare()"
+						class="hrfix" />
+					<label for="cbxHRFSquare" class="hrfix">Square Aspect</label>
 					<br class="hrfix" />
-					<label for="hrfOutX" class="hrfix">X:</label>
-					<input
-						type="number"
-						id="hr_resize_x"
-						onchange="changeHRFX()"
-						min="0"
-						max="2048"
-						value="0"
-						step="8"
-						class="hrfix thirdwidth" />
-					<label for="hrfOutY" class="hrfix">Y:</label>
-					<input
-						type="number"
-						id="hr_resize_y"
-						onchange="changeHRFY()"
-						min="0"
-						max="2048"
-						value="0"
-						step="8"
-						class="hrfix thirdwidth" />
 					<div id="hrFixScale" class="hrfix"></div>
 					<div id="hrFixLockPx" class="hrfix"></div>
 					<div id="hrFixSteps" class="hrfix"></div>

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
 			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=ac1cedd" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=18e3b66" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=1e8a893"
 			type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
 		<script src="js/global.js?v=3a1cde6" type="text/javascript"></script>
 
 		<!-- Base Libs -->
-		<script src="js/lib/util.js?v=5838390" type="text/javascript"></script>
+		<script src="js/lib/util.js?v=7f6847c" type="text/javascript"></script>
 		<script src="js/lib/events.js?v=2ab7933" type="text/javascript"></script>
 		<script src="js/lib/input.js?v=09298ac" type="text/javascript"></script>
 		<script src="js/lib/layers.js?v=a1f8aea" type="text/javascript"></script>
@@ -362,7 +362,7 @@
 
 		<!-- Load Tools -->
 		<script
-			src="js/ui/tool/generic.js?v=f1a19a4"
+			src="js/ui/tool/generic.js?v=2bcd36d"
 			type="text/javascript"></script>
 
 		<script src="js/ui/tool/dream.js?v=ac1cedd" type="text/javascript"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -114,6 +114,7 @@ var stableDiffusionData = {
 	hr_second_pass_steps: 0,
 	hr_resize_x: 0,
 	hr_resize_y: 0,
+	hr_square_aspect: false,
 	styles: [],
 	// here's some more fields that might be useful
 
@@ -729,23 +730,17 @@ function changeHiResFix() {
 		document
 			.querySelectorAll(".hrfix")
 			.forEach((el) => el.classList.remove("invisible"));
-		// hrfSlider.classList.remove("invisible");
-		// hrfOpotions.classList.remove("invisible");
-		// hrfLabel.classList.remove("invisible");
-		// hrfDenoiseSlider.classList.remove("invisible");
-		// hrfLockPxSlider.classList.remove("invisible");
-		//state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.add("invisible");
 	} else {
 		document
 			.querySelectorAll(".hrfix")
 			.forEach((el) => el.classList.add("invisible"));
-		// hrfSlider.classList.add("invisible");
-		// hrfOpotions.classList.add("invisible");
-		// hrfLabel.classList.add("invisible");
-		// hrfDenoiseSlider.classList.add("invisible");
-		// hrfLockPxSlider.classList.add("invisible");
-		//state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.remove("invisible");
 	}
+}
+
+function changeHiResSquare() {
+	stableDiffusionData.hr_square_aspect = Boolean(
+		document.getElementById("cbxHRFSquare").checked
+	);
 }
 
 function changeRestoreFaces() {
@@ -845,7 +840,17 @@ async function getUpscalers() {
 			.split(",")
 			.map((v) => v.trim()); // need "None" for stupid hrfix changes razza frazza
 		const upscalers = upscalersPlusNone.filter((v) => v !== "None"); // converting the result to a list of upscalers
+		// upscalersPlusNone.push([
+		// 	"Latent",
+		// 	"Latent (antialiased)",
+		// 	"Latent (bicubic)",
+		// 	"Latent (bicubic, antialiased)",
+		// 	"Latent (nearest)",
+		// ]);
 		upscalersPlusNone.push("Latent");
+		upscalersPlusNone.push("Latent (antialiased)");
+		upscalersPlusNone.push("Latent (bicubic)");
+		upscalersPlusNone.push("Latent (bicubic, antialiased)");
 		upscalersPlusNone.push("Latent (nearest)"); // GRUMBLE GRUMBLE
 
 		upscalerAutoComplete.options = upscalers.map((u) => {

--- a/js/index.js
+++ b/js/index.js
@@ -165,6 +165,7 @@ function startup() {
 	changeSmoothRendering();
 	changeSeed();
 	changeHiResFix();
+	changeHiResSquare();
 	changeRestoreFaces();
 	changeSyncCursorSize();
 }
@@ -690,7 +691,7 @@ const hrStepsSlider = makeSlider(
 	0,
 	localStorage.getItem("openoutpaint/settings.max-steps") || 70,
 	5,
-	30,
+	0,
 	1
 );
 

--- a/js/index.js
+++ b/js/index.js
@@ -111,6 +111,9 @@ var stableDiffusionData = {
 	//firstphase_height: 0, //20230102 welp looks like the entire way HRfix is implemented has become bonkersly different
 	hr_scale: 2.0,
 	hr_upscaler: "None",
+	hr_second_pass_steps: 0,
+	hr_resize_x: 0,
+	hr_resize_y: 0,
 	styles: [],
 	// here's some more fields that might be useful
 
@@ -679,6 +682,17 @@ const lockPxSlider = makeSlider(
 	1
 );
 
+const hrStepsSlider = makeSlider(
+	"HRfix Steps",
+	document.getElementById("hrFixSteps"),
+	"hr_second_pass_steps",
+	0,
+	localStorage.getItem("openoutpaint/settings.max-steps") || 70,
+	5,
+	30,
+	1
+);
+
 function changeMaskBlur() {
 	stableDiffusionData.mask_blur = parseInt(
 		document.getElementById("maskBlur").value
@@ -691,29 +705,45 @@ function changeSeed() {
 	localStorage.setItem("openoutpaint/seed", stableDiffusionData.seed);
 }
 
+function changeHRFX() {
+	stableDiffusionData.hr_resize_x =
+		document.getElementById("hr_resize_x").value;
+}
+
+function changeHRFY() {
+	stableDiffusionData.hr_resize_y =
+		document.getElementById("hr_resize_y").value;
+}
+
 function changeHiResFix() {
 	stableDiffusionData.enable_hr = Boolean(
 		document.getElementById("cbxHRFix").checked
 	);
 	localStorage.setItem("openoutpaint/enable_hr", stableDiffusionData.enable_hr);
-	var hrfSlider = document.getElementById("hrFixScale");
-	var hrfOpotions = document.getElementById("hrFixUpscaler");
-	var hrfLabel = document.getElementById("hrFixLabel");
-	var hrfDenoiseSlider = document.getElementById("hrDenoising");
-	var hrfLockPxSlider = document.getElementById("hrFixLockPx");
+	// var hrfSlider = document.getElementById("hrFixScale");
+	// var hrfOpotions = document.getElementById("hrFixUpscaler");
+	// var hrfLabel = document.getElementById("hrFixLabel");
+	// var hrfDenoiseSlider = document.getElementById("hrDenoising");
+	// var hrfLockPxSlider = document.getElementById("hrFixLockPx");
 	if (stableDiffusionData.enable_hr) {
-		hrfSlider.classList.remove("invisible");
-		hrfOpotions.classList.remove("invisible");
-		hrfLabel.classList.remove("invisible");
-		hrfDenoiseSlider.classList.remove("invisible");
-		hrfLockPxSlider.classList.remove("invisible");
+		document
+			.querySelectorAll(".hrfix")
+			.forEach((el) => el.classList.remove("invisible"));
+		// hrfSlider.classList.remove("invisible");
+		// hrfOpotions.classList.remove("invisible");
+		// hrfLabel.classList.remove("invisible");
+		// hrfDenoiseSlider.classList.remove("invisible");
+		// hrfLockPxSlider.classList.remove("invisible");
 		//state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.add("invisible");
 	} else {
-		hrfSlider.classList.add("invisible");
-		hrfOpotions.classList.add("invisible");
-		hrfLabel.classList.add("invisible");
-		hrfDenoiseSlider.classList.add("invisible");
-		hrfLockPxSlider.classList.add("invisible");
+		document
+			.querySelectorAll(".hrfix")
+			.forEach((el) => el.classList.add("invisible"));
+		// hrfSlider.classList.add("invisible");
+		// hrfOpotions.classList.add("invisible");
+		// hrfLabel.classList.add("invisible");
+		// hrfDenoiseSlider.classList.add("invisible");
+		// hrfLockPxSlider.classList.add("invisible");
 		//state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.remove("invisible");
 	}
 }

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -844,8 +844,16 @@ const dream_generate_callback = async (bb, resolution, state) => {
 
 			var newWidth = Math.floor(request.width / request.hr_scale);
 			var newHeight = Math.floor(request.height / request.hr_scale);
-			request.width = newWidth;
-			request.height = newHeight;
+			request.hr_resize_x = stableDiffusionData.hr_resize_x;
+			request.hr_resize_y = stableDiffusionData.hr_resize_y;
+			request.width =
+				stableDiffusionData.hr_resize_x || stableDiffusionData.hr_resize_y > 0
+					? request.width
+					: newWidth;
+			request.height =
+				stableDiffusionData.hr_resize_x || stableDiffusionData.hr_resize_y > 0
+					? request.height
+					: newHeight; //in webUI if _either_ x or y is > 0 then their values are used over scale as per https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/81490780949fffed77493b4bd741e96ec737fe27#diff-ddc07d50fa3b043925b1e831b1373976798d62c9f5c11fcb16c6c830bd3857cdR104
 		}
 
 		// For compatibility with the old HRFix API

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -844,20 +844,20 @@ const dream_generate_callback = async (bb, resolution, state) => {
 
 			var newWidth = Math.floor(request.width / request.hr_scale);
 			var newHeight = Math.floor(request.height / request.hr_scale);
-			request.hr_resize_x = stableDiffusionData.hr_resize_x;
-			request.hr_resize_y = stableDiffusionData.hr_resize_y;
-			request.width =
-				stableDiffusionData.hr_resize_x || stableDiffusionData.hr_resize_y > 0
-					? request.width
-					: newWidth;
-			request.height =
-				stableDiffusionData.hr_resize_x || stableDiffusionData.hr_resize_y > 0
-					? request.height
-					: newHeight; //in webUI if _either_ x or y is > 0 then their values are used over scale as per https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/81490780949fffed77493b4bd741e96ec737fe27#diff-ddc07d50fa3b043925b1e831b1373976798d62c9f5c11fcb16c6c830bd3857cdR104
+			if (stableDiffusionData.hr_square_aspect) {
+				larger = newWidth > newHeight ? newWidth : newHeight;
+				newWidth = larger;
+				newHeight = larger;
+			}
+			request.hr_resize_x = request.width;
+			request.hr_resize_y = request.height; // screw the scale, damn the man, setting specified output dimensions overrides it anyway, who needs the thing, i need to revisit like all the hrfix code now though because i don't know if NOT lying to it is even worthwhile anymore
+			request.width = newWidth;
+			request.height = newHeight;
 		}
 
 		// For compatibility with the old HRFix API
 		if (global.isOldHRFix && request.enable_hr) {
+			// For compatibility with the old HRFix API
 			request.firstphase_width = request.width / 2;
 			request.firstphase_height = request.height / 2;
 		}

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -820,13 +820,10 @@ const dream_generate_callback = async (bb, resolution, state) => {
 			/**
 			 * try and make the new HRfix method useful for our purposes
 			 */
-
-			//laziness convenience
+			// laziness convenience
 			let lockpx = stableDiffusionData.hr_fix_lock_px;
-			var divW = Math.floor(request.width / request.hr_scale);
-			var divH = Math.floor(request.height / request.hr_scale);
 			if (lockpx > 0) {
-				// find the appropriate scale factor for hrfix
+				// find the most appropriate scale factor for hrfix
 				var widthFactor =
 					request.width / lockpx <= 4 ? request.width / lockpx : 4;
 				var heightFactor =
@@ -834,6 +831,9 @@ const dream_generate_callback = async (bb, resolution, state) => {
 				var factor = heightFactor > widthFactor ? heightFactor : widthFactor;
 				request.hr_scale = hrFixScaleSlider.value = factor < 1 ? 1 : factor;
 			}
+			// moar laziness convenience
+			var divW = Math.floor(request.width / request.hr_scale);
+			var divH = Math.floor(request.height / request.hr_scale);
 
 			if (localStorage.getItem("openoutpaint/settings.hrfix-liar") == "true") {
 				/**
@@ -855,8 +855,7 @@ const dream_generate_callback = async (bb, resolution, state) => {
 
 			// ensure firstpass "resolution" complies with lockpx
 			if (lockpx > 0) {
-				//sigh repeated code
-				// scale down by hr_scale?
+				//sigh repeated loop
 				firstpassWidth = divW < lockpx ? divW : lockpx;
 				firstpassHeight = divH < lockpx ? divH : lockpx;
 			}

--- a/pages/configuration.html
+++ b/pages/configuration.html
@@ -84,11 +84,12 @@
 				step="0.1"
 				value="30.0" />
 		</label>
+		<!-- <p>Refresh the page to apply aabove.</p> -->
+		<hr />
 		<label style="display: flex">
 			Lie to HRfix:
 			<input id="hrfix-liar" class="canvas-size-input" type="checkbox" />
 		</label>
-		<p>Refresh the page to apply settings.</p>
 
 		<script>
 			const canvasWidth = document.getElementById("canvas-width");
@@ -127,8 +128,11 @@
 				localStorage.getItem("openoutpaint/settings.min-cfg") || -1;
 			maxCfg.value =
 				localStorage.getItem("openoutpaint/settings.max-cfg") || 30;
-			hrfixLiar.checked =
-				localStorage.getItem("openoutpaint/settings.hrfix-liar") || true;
+			let _enable_dishonesty =
+				localStorage.getItem("openoutpaint/settings.hrfix-liar") === null
+					? true
+					: localStorage.getItem("openoutpaint/settings.hrfix-liar") === "true";
+			hrfixLiar.checked = _enable_dishonesty;
 
 			writeToLocalStorage();
 

--- a/pages/configuration.html
+++ b/pages/configuration.html
@@ -7,7 +7,7 @@
 		<link href="../css/colors.css?v=3f81e80" rel="stylesheet" />
 		<link href="../css/icons.css?v=caa702e" rel="stylesheet" />
 
-		<link href="../css/index.css?v=69d3b9e" rel="stylesheet" />
+		<link href="../css/index.css?v=5b8d4d6" rel="stylesheet" />
 		<link href="../css/layers.css?v=b4fbf61" rel="stylesheet" />
 
 		<link href="../css/ui/generic.css?v=4b9afe2" rel="stylesheet" />


### PR DESCRIPTION
so this adds the new HRfix functionality like setting desired output resolution and 2nd-pass step count, and they _work_ and stuff but like i don't really know if they're useful at all here.  

to preface, there are 2 new inputs for "desired output resolution x/y" and a HRfix steps slider.  the steps slider is fine and isn't important here. [the x/y inputs completely override any supplied value for scale if either is >0](https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/81490780949fffed77493b4bd741e96ec737fe27#diff-ddc07d50fa3b043925b1e831b1373976798d62c9f5c11fcb16c6c830bd3857cdR102-R106) and herein lies the problem.

just like the [latent upscalers crashing if they're used against an inpainting model](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/6281) which doesn't seem to be a _prevalent_ issue, setting a desired output resolution also completely fails against inpainting models.  even if you're using a traditional model, setting a non-square output aspect ratio results in pretty trash output if you inadvertantly use a square reticle, etc etc pebkac whatever, i'm a pessimist :| 

i've tried making a local "override settings" branch to specify a non-inpainting model on the first shot which worked as expected, but the internal webUI call reverting those override settings happens BEFORE the HRfix upscaling, so the upscaling tries to run against the inpainting model making it entirely useless.  

anyway i have no idea and my brain is melt

is this even worth committing? like i'd rather give people the flexibility but this just seems to almost fight how openOutpaint... works

[edit]

i think i'm an idiot and just rubberducked my being an idiot; hold please, further commits incoming