### PR TITLE
remove absolute path for reverse proxy

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -391,7 +391,7 @@ async function testHostConnection() {
 			} else {
 				// Check if API is available
 				const response = await fetch(
-					document.getElementById("host").value + "/sdapi/v1/options"
+					"/sdapi/v1/options"
 				);
 				const optionsdata = await response.json();
 				if (optionsdata["use_scale_latent_for_hires_fix"]) {


### PR DESCRIPTION
Hi, thanks for the great extension.
Sorry, I accidentally closed the PR earlier.

If you want to run WebUI on public cloud (aws, gcp, etc) with https, there is a restriction that you can not directly bind to the external address from inside the machine, so I think it is common to do as follows.
・Bind the WebUI to the local address (127.0.0.1)
・Bind nginx to an external address and operate as a reverse proxy to transfer to WebUI

However, since there is a part written with an absolute path, javascript seems to get stuck trying to access the user's local machine (127.0.0.1). If there is a reason why it must be an absolute path, I will give up, but I would be happy if you could merge it.

Thanks.