### PR TITLE
Slider visibility & variable typo corrected

### DIFF
--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -2015,12 +2015,12 @@ const dreamTool = () =>
 								state.ctxmenu.keepUnmaskedBlurSlider.classList.remove(
 									"invisible"
 								);
-								state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.add(
+								state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.remove(
 									"invisible"
 								);
 							} else {
 								state.ctxmenu.keepUnmaskedBlurSlider.classList.add("invisible");
-								state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.remove(
+								state.ctxmenu.keepUnmaskedBlurSliderLinebreak.classList.add(
 									"invisible"
 								);
 							}
@@ -2184,6 +2184,21 @@ const dreamTool = () =>
 				menu.appendChild(state.ctxmenu.outpaintTypeSelect);
 				menu.appendChild(state.ctxmenu.overMaskPxLabel);
 				menu.appendChild(state.ctxmenu.eagerGenerateCountLabel);
+				
+				if (localStorage.getItem("openoutpaint/dream-keepunmasked") == "true") {
+					state.ctxmenu.keepUnmaskedBlurSlider.classList.remove("invisible");
+				} else {
+					state.ctxmenu.keepUnmaskedBlurSlider.classList.add("invisible");
+				}
+
+				if (localStorage.getItem("openoutpaint/dream-removebg") == "true") {
+					state.ctxmenu.carveBlurSlider.classList.remove("invisible");
+					state.ctxmenu.carveThresholdSlider.classList.remove("invisible");
+				} else {
+					state.ctxmenu.carveBlurSlider.classList.add("invisible");
+					state.ctxmenu.carveThresholdSlider.classList.add("invisible");
+				}
+				
 			},
 			shortcut: "D",
 		}
@@ -2848,6 +2863,21 @@ const img2imgTool = () =>
 				menu.appendChild(btnArray2);
 				menu.appendChild(state.ctxmenu.borderMaskSlider);
 				menu.appendChild(state.ctxmenu.eagerGenerateCountLabel);
+
+				if (localStorage.getItem("openoutpaint/img2img-keepunmasked") == "true") {
+					state.ctxmenu.keepUnmaskedBlurSlider.classList.remove("invisible");
+				} else {
+					state.ctxmenu.keepUnmaskedBlurSlider.classList.add("invisible");
+				}
+
+				if (localStorage.getItem("openoutpaint/img2img-removebg") == "true") {
+					state.ctxmenu.carveBlurSlider.classList.remove("invisible");
+					state.ctxmenu.carveThresholdSlider.classList.remove("invisible");
+				} else {
+					state.ctxmenu.carveBlurSlider.classList.add("invisible");
+					state.ctxmenu.carveThresholdSlider.classList.add("invisible");
+				}
+
 			},
 			shortcut: "I",
 		}

--- a/js/ui/tool/select.js
+++ b/js/ui/tool/select.js
@@ -420,7 +420,7 @@ const selectTransformTool = () =>
 						const lscursor = m.transformPoint({x: sx, y: sy});
 
 						const xs = lscursor.x / scaling.handle.x;
-						const xy = lscursor.y / scaling.handle.y;
+						const ys = lscursor.y / scaling.handle.y;
 
 						let xscale = 1;
 						let yscale = 1;
@@ -429,7 +429,7 @@ const selectTransformTool = () =>
 							xscale = xs;
 							yscale = ys;
 						} else {
-							xscale = yscale = Math.max(xs, xy);
+							xscale = yscale = Math.max(xs, ys);
 						}
 
 						state.selected.scale = {x: xscale, y: yscale};


### PR DESCRIPTION
The visibility of the sliders _Keep Unmasked Blur_ and both of the _BG Remove_ is wrong when the web page gets (re)loaded. This is now corrected. Its is more a cosmetic issue than a bug.

I just want to mention that openOutpaint is the best tool for in/outpaint, I still use it a lot. Keep up the good work!