### PR TITLE
Select tool overhaul

### DIFF
--- a/css/icons.css
+++ b/css/icons.css
@@ -208,9 +208,3 @@
 	-webkit-mask-image: url("../res/icons/file-plus.svg");
 	mask-image: url("../res/icons/file-plus.svg");
 }
-
-.ui.inline-icon.icon-lock::after,
-.ui.icon > .icon-lock {
-	-webkit-mask-image: url("../res/icons/lock.svg");
-	mask-image: url("../res/icons/lock.svg");
-}

--- a/css/icons.css
+++ b/css/icons.css
@@ -202,3 +202,15 @@
 	-webkit-mask-image: url("../res/icons/squircle.svg");
 	mask-image: url("../res/icons/squircle.svg");
 }
+
+.ui.inline-icon.icon-file-plus::after,
+.ui.icon > .icon-file-plus {
+	-webkit-mask-image: url("../res/icons/file-plus.svg");
+	mask-image: url("../res/icons/file-plus.svg");
+}
+
+.ui.inline-icon.icon-lock::after,
+.ui.icon > .icon-lock {
+	-webkit-mask-image: url("../res/icons/lock.svg");
+	mask-image: url("../res/icons/lock.svg");
+}

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
@@ -339,7 +339,7 @@
 					<br />
 					<span id="version">
 						<a href="https://github.com/zero01101/openOutpaint" target="_blank">
-							v20240807.001
+							v20240824.001
 						</a>
 						<br />
 						<a
@@ -545,7 +545,7 @@
 			type="text/javascript"></script>
 		<script src="js/lib/events.js?v=2ab7933" type="text/javascript"></script>
 		<script src="js/lib/db.js?v=434363b" type="text/javascript"></script>
-		<script src="js/lib/input.js?v=769485c" type="text/javascript"></script>
+		<script src="js/lib/input.js?v=f99493d" type="text/javascript"></script>
 		<script src="js/lib/layers.js?v=26b7436" type="text/javascript"></script>
 		<script src="js/lib/commands.js?v=ad60afc" type="text/javascript"></script>
 

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
@@ -339,7 +339,7 @@
 					<br />
 					<span id="version">
 						<a href="https://github.com/zero01101/openOutpaint" target="_blank">
-							v20240427.001
+							v20240807.001
 						</a>
 						<br />
 						<a
@@ -576,7 +576,7 @@
 			src="js/ui/tool/generic.js?v=3e678e0"
 			type="text/javascript"></script>
 
-		<script src="js/ui/tool/dream.js?v=56c7c50" type="text/javascript"></script>
+		<script src="js/ui/tool/dream.js?v=9ae0612" type="text/javascript"></script>
 		<script
 			src="js/ui/tool/maskbrush.js?v=e9bd0eb"
 			type="text/javascript"></script>
@@ -612,3 +612,4 @@
 		<script src="js/webui.js?v=ccd423a" type="text/javascript"></script>
 	</body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-US">
 	<head>
 		<meta charset="utf-8" />
@@ -612,4 +612,3 @@
 		<script src="js/webui.js?v=ccd423a" type="text/javascript"></script>
 	</body>
 </html>
-

--- a/js/index.js
+++ b/js/index.js
@@ -1534,7 +1534,7 @@ async function upscaleAndDownload(
 			body: JSON.stringify(data),
 		})
 			.then((response) => response.json())
-			.then((data) => {
+			.then(async (data) => {
 				console.log(data);
 				var link = document.createElement("a");
 				link.download =
@@ -1554,6 +1554,7 @@ async function upscaleAndDownload(
 					console.log("Add upscaled to resource");
 					const img = new Image();
 					img.src = link.href;
+					await img.decode();
 					tools.stamp.state.addResource(guid() + " (upscaled)", img);
 				}
 				if (download == true) {

--- a/js/lib/input.js
+++ b/js/lib/input.js
@@ -660,6 +660,9 @@ window.onkeyup = (evn) => {
 		});
 	}
 
+	if (keyboard.keys[evn.code]._hold_to)
+		clearTimeout(keyboard.keys[evn.code]._hold_to);
+
 	keyboard.keys[evn.code] = {
 		pressed: false,
 		held: false,

--- a/js/ui/tool/dream.js
+++ b/js/ui/tool/dream.js
@@ -3339,6 +3339,7 @@ function addControlNetToAlwaysOnScripts(state, initCanvas, maskCanvas) {
 			//img2img?
 			state.alwayson_scripts.controlnet.args = [
 				{
+					enabled: true,
 					module: extensions.selectedControlNetModule,
 					model: extensions.selectedControlNetModel,
 					control_mode: document.getElementById("controlNetMode-select").value,
@@ -3351,10 +3352,11 @@ function addControlNetToAlwaysOnScripts(state, initCanvas, maskCanvas) {
 		} else {
 			state.alwayson_scripts.controlnet.args = [
 				{
+					enabled: true,
 					module: extensions.selectedControlNetModule,
 					model: extensions.selectedControlNetModel,
 					control_mode: document.getElementById("controlNetMode-select").value,
-					input_image: initimg, //initCanvas.toDataURL(),
+					image: initimg, //initCanvas.toDataURL(),
 					mask: maskimg, //maskCanvas.toDataURL(),
 					processor_res: 64,
 					resize_mode: document.getElementById("controlNetResize-select").value,

--- a/js/ui/tool/select.js
+++ b/js/ui/tool/select.js
@@ -957,8 +957,8 @@ const selectTransformTool = () =>
 					// Clear Button
 					const applyClearButton = document.createElement("button");
 					applyClearButton.classList.add("button", "tool");
-					applyClearButton.textContent = "Clear and Apply";
-					applyClearButton.title = "Erases everything in the current layer other than the selection (Shift+Delete)";
+					applyClearButton.textContent = "Erase Outside";
+					applyClearButton.title = "Erases everything in the current layer outside the selection (Shift+Delete)";
 					applyClearButton.onclick = () => { state.applyTransform(false,true,false,false); };
 					
 					// Erase Button

--- a/js/ui/tool/select.js
+++ b/js/ui/tool/select.js
@@ -23,6 +23,9 @@ const selectTransformTool = () =>
 
 			// Layer system handlers
 			uil.onactive.on(state.uilayeractivecb);
+			
+			commands.onundo.on(state.undocb);
+			commands.onredo.on(state.redocb);
 
 			// Registers keyboard shortcuts
 			keyboard.onShortcut({ctrl: true, key: "KeyA"}, state.ctrlacb);
@@ -65,6 +68,9 @@ const selectTransformTool = () =>
 
 			uil.onactive.clear(state.uilayeractivecb);
 
+			commands.onundo.clear(state.undocb);
+			commands.onredo.clear(state.redocb);
+			
 			// Clear any selections
 			state.reset();
 
@@ -179,6 +185,17 @@ const selectTransformTool = () =>
 						);
 					}
 				};
+				
+				// Undo/Redo Handling, reset state before Undo/Redo
+				state.undocb= (undo)=>{
+					if (state.selected){
+						if (undo.n<=1) undo.cancel();
+						state.reset(false);
+					}
+				}				
+				state.redocb= (redo)=>{
+					if (state.selected){ state.reset(false); }
+				}
 
 				// Mirroring
 				state.togglemirror = () => {

--- a/js/ui/tool/select.js
+++ b/js/ui/tool/select.js
@@ -718,7 +718,7 @@ const selectTransformTool = () =>
 				// Only checks if Selection exists and content has been selected
 				// Does not check if content has been transformed, eg for deletion/applying to new layer
 				state.applyTransform = async (eraseSelected = false, clearLayer = false, newLayer = null, keepOriginal = false) => {
-						const isBlank = 
+						const isBlank = !state.selected ||
 							isCanvasBlank( 0, 0, state.selected.canvas.width, state.selected.canvas.height, state.selected.canvas);
 							
 						// Just reset state if nothing is selected, unless Clearing layer

--- a/js/ui/tool/select.js
+++ b/js/ui/tool/select.js
@@ -557,6 +557,7 @@ const selectTransformTool = () =>
 
 				// Register Ctrl-A Shortcut
 				state.ctrlacb = () => {
+					state.reset(false); // Reset to preserve selected content
 					try {
 						const {bb} = cropCanvas(uil.canvas);
 						select(bb);
@@ -566,6 +567,8 @@ const selectTransformTool = () =>
 				};
 
 				state.ctrlsacb = () => {
+					state.reset(false); // Reset to preserve selected content
+
 					// Shift Key selects based on all visible layer information
 					const tl = {x: Infinity, y: Infinity};
 					const br = {x: -Infinity, y: -Infinity};

--- a/pages/embed.test.html
+++ b/pages/embed.test.html
@@ -72,4 +72,3 @@
 		</script>
 	</body>
 </html>
-

--- a/pages/embed.test.html
+++ b/pages/embed.test.html
@@ -8,7 +8,7 @@
 		<iframe
 			id="openoutpaint"
 			style="width: 100%; height: 800px"
-			src="../index.html?v=34d5675"
+			src="../index.html?v=f393a6b"
 			frameborder="0"></iframe>
 		<button id="add-res">Add Resource</button>
 		<script>
@@ -72,3 +72,4 @@
 		</script>
 	</body>
 </html>
+

--- a/test.html
+++ b/test.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<title>Test</title>
+	</head>
+	<body>
+		<h1>Test</h1>
+		<p>Test</p>
+	</body>
+</html>


### PR DESCRIPTION
I had some time to kill and went in to fix a few issues with the select tool, but wound up doing a minor overhaul, and figured someone else might find it useful. Mostly UI and adding controls. Other than applying the final transform, the core functionality is mostly unchanged. 

While none of the other tools were in need of as much attention as select, I've made similar updates to a few of them. If y'all aren't willing to accept these sorts of changes, let me know, and I won't bother cleaning them up.

Changes:

Reset State in the Ctrl+A shortcuts so that the current selection isn't lost when the shortcuts are used with a transformed selection. Previously, if you selected a region, moved it, then hit Ctrl+A, the transformed selection was lost. (Might want to apply instead, but resetting seems like the safest option.)

Fix History State Desynchronization when undo/redo is called while a selection is active. For example, previously, moving a selection, calling an undo that removes the active layer, then cancelling the transform with R-click, would place the restored image in an inaccessible layer.
To do this, added onundo/onredo callbacks to the commands object in commands.js (Only major change outside of select.js). These are called before undoing/redoing, and provide a function that can be called to cancel the undo/redo. 
Selection state is now reset before all undo/redo commands. Performing an undo with a transformed selection resets the selection and cancels the undo, unless going back multiple steps. So undo effectively undoes the current transformation.

Refactored how Transformation is applied to make it easier to add shortcuts and additional functionality.

Fixed the broken "Delete" hotkey that completely broke history.

Added a toggle to always move to a new layer when transforming a selection. (file-plus icon)

Added "Layer" buttons to the Save Selection/Save Visible buttons that copy selected content to a new layer. Reworked their UI a bit to fit everything. 

Added a new row of buttons
- Isolate - Clears everything but the selection from the current layer.
- Erase - Erases the current selection 
- Extract - Moves the current selection to a new layer.

Mouse Controls
- Double Left Click - Select All (Ctrl+A)
- Shift+Double Left Click - Select All Visible (Ctrl+Shift+A)
- Double Right Click - Select Topmost Layer with visible content under pointer.
- Shift+Double Right Click - Shifts down through layers with visible content under pointer. (Selects the next topmost if current has visible content under pointer.)

Keyboard Shortcuts
- Enter - Apply Transform (Same as L-Click)
- Shift+Enter - Extract - Apply Transform and Move the current selection to a new layer.
- Shift+Delete - Isolate - Clears everything but the selection from the current layer.
- Ctrl+Enter - Copy Selection to new layer, restore original
- Ctrl+Shift+Enter - Copy Visible Selection to new layer 